### PR TITLE
Rails 2.3.9 patch -- Rails 2.3.9 requires a destroy method for session stores

### DIFF
--- a/lib/rack/session/rails.rb
+++ b/lib/rack/session/rails.rb
@@ -54,6 +54,14 @@ module RedisStore
         rescue Errno::ECONNREFUSED
           return false
         end
+
+        def destroy(env)
+          if sid = current_session_id(env)
+            @pool.del(prefixed(sid))
+          end
+        rescue Errno::ECONNREFUSED
+          false
+        end
       end
     end
   end

--- a/lib/redis/distributed_marshaled.rb
+++ b/lib/redis/distributed_marshaled.rb
@@ -24,5 +24,9 @@ class Redis
     def marshalled_setnx(key, value, options = nil)
       node_for(key).marshalled_setnx(key, value, options)
     end
+
+    def del(key)
+      node_for(key).del(key)
+    end
   end
 end


### PR DESCRIPTION
I guess they finally decided to make Rails delete server side sessions when the session is reset: https://rails.lighthouseapp.com/projects/8994/tickets/4938-patch-session-fixes-sessions-should-not-be-created-until-written-to-and-session-data-should-be-destroyed-on-session-reset

Here is the relevant code from MemCacheStore:

http://github.com/rails/rails/blob/v2.3.9/actionpack/lib/action_controller/session/mem_cache_store.rb#L47-53
