### PR TITLE
Rails3 sessions issue

### DIFF
--- a/lib/action_controller/session/redis_session_store.rb
+++ b/lib/action_controller/session/redis_session_store.rb
@@ -46,7 +46,7 @@ module RedisStore
           def set_session(env, sid, session_data)
             options = env['rack.session.options']
             @pool.set(sid, session_data, options)
-            return true
+            return(::Redis::Store.rails3? ? sid : true)
           rescue Errno::ECONNREFUSED
             return false
           end


### PR DESCRIPTION
Hi,

I have fixed the Rails 3 sessions compatibility issue, it was always setting the session_id to the value 'true'. The set_session method should return the sid value in rails3. There are no test yet as I have not seen any specs for rails3, any plans for that ?

Cheers,
Danoo
