### PR TITLE
Support all Rails3 versions

### DIFF
--- a/lib/redis/store.rb
+++ b/lib/redis/store.rb
@@ -9,7 +9,7 @@ class Redis
     end
 
     def self.rails3? #:nodoc:
-      defined?(::Rails) && ::Rails.version =~ /3\.0\.0/
+      defined?(::Rails) && ::Rails.version =~ /3\.[0-9]+\.[0-9]+/
     end
 
     def to_s


### PR DESCRIPTION
Redis::Store.rails3? return nil with Rails 3.0.1 version 
