### PR TITLE
Support for password in Redis URI resolution

### DIFF
--- a/lib/rack/cache/redis_entitystore.rb
+++ b/lib/rack/cache/redis_entitystore.rb
@@ -15,7 +15,7 @@ module Rack
         def self.resolve(uri)
           db = uri.path.sub(/^\//, '')
           db = "0" if db.empty?
-          server = { :host => uri.host, :port => uri.port || "6379", :db => db }
+          server = { :host => uri.host, :port => uri.port || "6379", :db => db, :password => uri.password }
           new server
         end
       end

--- a/lib/rack/cache/redis_metastore.rb
+++ b/lib/rack/cache/redis_metastore.rb
@@ -10,7 +10,7 @@ module Rack
         def self.resolve(uri)
           db = uri.path.sub(/^\//, '')
           db = "0" if db.empty?
-          server = { :host => uri.host, :port => uri.port || "6379", :db => db }
+          server = { :host => uri.host, :port => uri.port || "6379", :db => db, :password => uri.password }
           new server
         end
       end

--- a/spec/rack/cache/entitystore/redis_spec.rb
+++ b/spec/rack/cache/entitystore/redis_spec.rb
@@ -31,6 +31,10 @@ module Rack
 
           cache = Rack::Cache::EntityStore::Redis.resolve(uri("redis://127.0.0.1/13")).cache
           cache.id.should == "redis://127.0.0.1:6379/13"
+
+          cache = Rack::Cache::EntityStore::Redis.resolve(uri("redis://:secret@127.0.0.1")).cache
+          cache.id.should == "redis://127.0.0.1:6379/0"
+          cache.client.password.should == 'secret'
         end
 
         # Entity store shared examples ===========================================

--- a/spec/rack/cache/metastore/redis_spec.rb
+++ b/spec/rack/cache/metastore/redis_spec.rb
@@ -31,6 +31,10 @@ module Rack
 
           cache = Rack::Cache::MetaStore::Redis.resolve(uri("redis://127.0.0.1/13")).cache
           cache.to_s.should == "Redis Client connected to 127.0.0.1:6379 against DB 13"
+
+          cache = Rack::Cache::MetaStore::Redis.resolve(uri("redis://:secret@127.0.0.1")).cache
+          cache.id.should == "redis://127.0.0.1:6379/0"
+          cache.client.password.should == 'secret'
         end
 
         # Low-level implementation methods ===========================================


### PR DESCRIPTION
I have added support for Redis password in <code>Rack::Cache::MetaStore::RedisBase.resolve</code> and <code>Rack::Cache::MetaStore::RedisBase.resolve</code>. I am passing in <code>URI#password</code> to the Redis server options hash.

Please let me know if there are any improvements to be made. Thanks.

Cheers,
Jacob
