### PR TITLE
Sinatra::Cache fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,11 @@ For advanced configurations scenarios please visit [the wiki](http://wiki.github
     class MyApp < Sinatra::Base
       register Sinatra::Cache
       get "/hi" do
-        cache.fetch("greet") { "Hello, World!" }
+        settings.cache.fetch("greet") { "Hello, World!" }
       end
     end
+
+Keep in mind that the above fetch will return "OK" on success, not the return of the block.
 
 ## Rack::Session
 

--- a/lib/cache/sinatra/redis_store.rb
+++ b/lib/cache/sinatra/redis_store.rb
@@ -4,6 +4,7 @@ module Sinatra
       def register(app)
         app.set :cache, RedisStore.new
       end
+      alias_method :registered, :register
     end
 
     class RedisStore


### PR DESCRIPTION
It seems as if Sinatra changed its API to call 'registered' instead of 'register', so i aliases the method. Also, in order to use this one must access the variable via the 'settings' variable due to scope.

Let me know if you would like me to send this pull request another way, via ticket etc.

Michael
