### PR TITLE
Redis server parameters with Sinatra

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ For advanced configurations scenarios please visit [the wiki](http://wiki.github
     require "redis-store"
 
     class MyApp < Sinatra::Base
-      use Rack::Session::Redis
+      use Rack::Session::Redis, :redis_server => 'redis://127.0.0.1:6379/0' # Redis server on localhost port 6379, database 0
 
       get "/" do
         session[:visited_at] = DateTime.now.to_s # This is stored in Redis


### PR DESCRIPTION
I had to refer to the source of lib/rack/session/redis.rb to figure out how to configure the Redis server parameters when using Redis as a session store with Sinatra. Hopefully this comment in the README will make it clear to other users how to do that.

redis-store is awesome!

-Christian
