### PR TITLE
Re-implement the delete_entry because it s needed by the ActiveSupport::Cache

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -124,6 +124,18 @@ module ::RedisStore
           nil
         end
 
+        ##
+        # Implement the ActiveSupport::Cache#delete_entry
+        #
+        # It's really needed and use
+        #
+        def delete_entry(key, options)
+          @data.del key
+        rescue Errno::ECONNREFUSED => e
+          false
+        end
+
+
         # Add the namespace defined in the options to a pattern designed to match keys.
         #
         # This implementation is __different__ than ActiveSupport:


### PR DESCRIPTION
Re-implement the delete_entry because it s needed by the ActiveSupport::Cache implementation in Rails 3

The #delete_entry method was delete on commit : 938ae331fa0ed69b4e3a6c19e010654dd17f9675
