### PR TITLE
Modify #fetch for cache stores to return the yielded value instead of OK

### DIFF
--- a/lib/cache/merb/redis_store.rb
+++ b/lib/cache/merb/redis_store.rb
@@ -45,9 +45,13 @@ module Merb
       end
 
       def fetch(key, parameters = {}, conditions = {}, &blk)
-        read(key, parameters) || (write key, yield, parameters, conditions if block_given?)
+        (data = read(key, parameters)) || block_given? && begin
+          data = yield
+          write(key, data, parameters, conditions)
+        end
+        data || nil
       end
-
+      
       def exists?(key, parameters = {})
         @data.exists normalize(key, parameters)
       end

--- a/lib/cache/sinatra/redis_store.rb
+++ b/lib/cache/sinatra/redis_store.rb
@@ -111,7 +111,11 @@ module Sinatra
       end
 
       def fetch(key, options = {})
-        (!options[:force] && data = read(key, options)) || (write key, yield, options if block_given?)
+        (!options[:force] && data = read(key, options)) || block_given? && begin
+          data = yield
+          write(key, data, options)
+        end
+        data || nil
       end
 
       # Clear all the data from the store.

--- a/spec/cache/merb/redis_store_spec.rb
+++ b/spec/cache/merb/redis_store_spec.rb
@@ -96,7 +96,7 @@ module Merb
         with_store_management do |store|
           store.fetch("rabbit").should == @rabbit
           store.fetch("rub-a-dub").should be_nil
-          store.fetch("rub-a-dub") { "Flora de Cana" }
+          store.fetch("rub-a-dub") { "Flora de Cana" }.should == "Flora de Cana"
           store.fetch("rub-a-dub").should === "Flora de Cana"
         end
       end

--- a/spec/cache/sinatra/redis_store_spec.rb
+++ b/spec/cache/sinatra/redis_store_spec.rb
@@ -169,7 +169,7 @@ module Sinatra
         with_store_management do |store|
           store.fetch("rabbit").should == @rabbit
           store.fetch("rub-a-dub").should be_nil
-          store.fetch("rub-a-dub") { "Flora de Cana" }
+          store.fetch("rub-a-dub") { "Flora de Cana" }.should == "Flora de Cana"
           store.fetch("rub-a-dub").should === "Flora de Cana"
           store.fetch("rabbit", :force => true).should be_nil # force cache miss
           store.fetch("rabbit", :force => true, :expires_in => 1.second) { @white_rabbit }


### PR DESCRIPTION
This will probably break projects depending on the "OK" return value, but I feel this is a better API that allows for much cleaner application code. Passing specs attached. Usage example:

``` ruby
get '/' do
  settings.cache.fetch('something') do
    HeavyAPI.query(params[:query])
  end
end
```
