### PR TITLE
ActiveSupport cache stores reply to read_multi with a hash, not an array.

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -170,7 +170,14 @@ module ActiveSupport
       #   cache.read_multi "rabbit", "white-rabbit"
       #   cache.read_multi "rabbit", "white-rabbit", :raw => true
       def read_multi(*names)
-        @data.mget *names
+        values = @data.mget(*names)
+        
+        # Remove the options hash before mapping keys to values
+        names.extract_options!
+        
+        result = Hash[names.zip(values)]
+        result.reject!{ |k,v| v.nil? }
+        result
       end
 
       # Increment a key in the store.

--- a/spec/active_support/cache/redis_store_spec.rb
+++ b/spec/active_support/cache/redis_store_spec.rb
@@ -210,17 +210,23 @@ module ActiveSupport
       if ::Redis::Store.rails3?
         it "should read multiple keys" do
           @store.write "irish whisky", "Jameson"
-          rabbit, whisky = @store.read_multi "rabbit", "irish whisky"
-          rabbit.raw_value.should === @rabbit
-          whisky.raw_value.should == "Jameson"
+          result = @store.read_multi "rabbit", "irish whisky"
+          result['rabbit'].raw_value.should === @rabbit
+          result['irish whisky'].raw_value.should == "Jameson"
         end
       else
         it "should read multiple keys" do
           @store.write "irish whisky", "Jameson"
-          rabbit, whisky  = @store.read_multi "rabbit", "irish whisky"
-          rabbit.should === @rabbit
-          whisky.should  == "Jameson"
+          result = @store.read_multi "rabbit", "irish whisky"
+          result.should == { 'rabbit' => @rabbit, 'irish whisky' => 'Jameson' }
         end
+      end
+      
+      it 'should read multiple keys and return only matches' do
+        @store.delete 'irish whisky'
+        result = @store.read_multi "rabbit", "irish whisky"
+        result.should_not include('irish whisky')
+        result.should include('rabbit')
       end
 
       describe "namespace" do


### PR DESCRIPTION
Patch fixes the semantics of the redis ActiveSupport cache store so that read_multi returns a hash instead of a value array. This behavior is consistent with other AS stores.
