### PR TITLE
`RedisStore::Rack::Session::Rails#destroy` doesn't return a session id. In real life, this makes all users share the same session

### DIFF
--- a/lib/action_controller/session/redis_session_store.rb
+++ b/lib/action_controller/session/redis_session_store.rb
@@ -54,6 +54,7 @@ module RedisStore
           def destroy(env)
             if sid = current_session_id(env)
               @pool.del(sid)
+              sid
             end
           rescue Errno::ECONNREFUSED
             false


### PR DESCRIPTION
Warning: this is a pretty critical bug for users of Redis as a session store in Rails.

`Rack::Session::Abstract::ID` expects a session id to be returned by `#destroy` :
https://github.com/rack/rack/blob/master/lib/rack/session/abstract/id.rb#L293

In our application, this happens when Devise authenticates an user (it tries to create a cookie with `:renew => true`).

The net result is that all the users that try to login will end up with the same `session_id` (either 0 or 1, the result of the Redis key deletion call), and, in the end, share the same session.
