### PR TITLE
Don't always connect to localhost in rails 3.1

### DIFF
--- a/lib/rack/session/redis.rb
+++ b/lib/rack/session/redis.rb
@@ -8,7 +8,7 @@ module Rack
         super
         @mutex = Mutex.new
         options[:redis_server] ||= @default_options[:redis_server]
-        @pool = ::Redis::Factory.create options
+        @pool = ::Redis::Factory.create options[:redis_server]
       end
 
       def generate_sid


### PR DESCRIPTION
redis_server is a redis URI which should be passed to the factory. The current implementation does not correctly parse the URI into redis client connect options, resulting in always connecting to localhost in the redis client.

The correct behaviour is present in prior commits, broken in last change to this file. This resolves that issue.
