### PR TITLE
Redis_server with fallback to host/port mechanism

### DIFF
--- a/lib/rack/session/redis.rb
+++ b/lib/rack/session/redis.rb
@@ -7,8 +7,9 @@ module Rack
       def initialize(app, options = {})
         super
         @mutex = Mutex.new
-        options[:redis_server] ||= @default_options[:redis_server]
-        @pool = ::Redis::Factory.create options[:redis_server]
+        options.merge! ::Redis::Factory.convert_to_redis_client_options(options[:redis_server]) if options[:redis_server]
+        options.merge! ::Redis::Factory.convert_to_redis_client_options(DEFAULT_OPTIONS) unless options[:host]
+        @pool = ::Redis::Factory.create options
       end
 
       def generate_sid


### PR DESCRIPTION
This provides the graceful fallback as per comments on my last pull request.
