### PR TITLE
Install bundler 1.1 RC on travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+before_install: gem install bundler --pre
 script: 'ci/travis.rb'
 rvm:
   - 1.8.7


### PR DESCRIPTION
Your test suite seems to be [failing](http://travis-ci.org/#!/jodosha/redis-store/jobs/446482) due to bundler 1.1rc being specified in the Gemfile. I am not sure why you even have it there but in any case, you can use `before_install` on travis-ci.org to switch to bundler 1.1.rc.

On behalf of the travis-ci.org team, MK.
