### PR TITLE
Ensure Cache TTL is an integer

### DIFF
--- a/lib/redis/store/ttl.rb
+++ b/lib/redis/store/ttl.rb
@@ -3,7 +3,7 @@ class Redis
     module Ttl
       def set(key, value, options = nil)
         if ttl = expires_in(options)
-          setex(key, ttl, value)
+          setex(key, ttl.to_i, value)
         else
           super(key, value)
         end
@@ -11,7 +11,7 @@ class Redis
 
       def setnx(key, value, options = nil)
         if ttl = expires_in(options)
-          setnx_with_expire(key, value, ttl)
+          setnx_with_expire(key, value, ttl.to_i)
         else
           super(key, value)
         end


### PR DESCRIPTION
Rails cache returns a float when used with race_condition_ttl which causes a redis error:

ERR value is not an integer
