### PR TITLE
Add Rails 3.2.2 support in redis-actionpack, redis-activesupport, redis-rails

### DIFF
--- a/redis-actionpack/lib/redis/actionpack/version.rb
+++ b/redis-actionpack/lib/redis/actionpack/version.rb
@@ -1,5 +1,5 @@
 class Redis
   module ActionPack
-    VERSION = '3.2.1'
+    VERSION = '3.2.2'
   end
 end

--- a/redis-actionpack/redis-actionpack.gemspec
+++ b/redis-actionpack/redis-actionpack.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'redis-store', '~> 1.1.0'
   s.add_runtime_dependency 'redis-rack',  '~> 1.4.0'
-  s.add_runtime_dependency 'actionpack',  '3.2.1'
+  s.add_runtime_dependency 'actionpack',  '3.2.2'
 
   s.add_development_dependency 'rake',           '~> 0.9.2.2'
   s.add_development_dependency 'bundler',        '~> 1.1.rc'

--- a/redis-actionpack/test/redis/actionpack/version_test.rb
+++ b/redis-actionpack/test/redis/actionpack/version_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 describe Redis::ActionPack::VERSION do
-  it "must be equal to 3.2.1" do
-    Redis::ActionPack::VERSION.must_equal '3.2.1'
+  it "must be equal to 3.2.2" do
+    Redis::ActionPack::VERSION.must_equal '3.2.2'
   end
 end

--- a/redis-activesupport/lib/redis/activesupport/version.rb
+++ b/redis-activesupport/lib/redis/activesupport/version.rb
@@ -1,5 +1,5 @@
 class Redis
   module ActiveSupport
-    VERSION = '3.2.1'
+    VERSION = '3.2.2'
   end
 end

--- a/redis-activesupport/redis-activesupport.gemspec
+++ b/redis-activesupport/redis-activesupport.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency 'redis-store',   '~> 1.1.0'
-  s.add_runtime_dependency 'activesupport', '3.2.1'
+  s.add_runtime_dependency 'activesupport', '3.2.2'
 
   s.add_development_dependency 'rake',      '~> 0.9.2.2'
   s.add_development_dependency 'bundler',   '~> 1.1.rc'

--- a/redis-activesupport/test/redis/activesupport/version_test.rb
+++ b/redis-activesupport/test/redis/activesupport/version_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 describe Redis::ActiveSupport::VERSION do
-  it "must be equal to 3.2.1" do
-    Redis::ActiveSupport::VERSION.must_equal '3.2.1'
+  it "must be equal to 3.2.2" do
+    Redis::ActiveSupport::VERSION.must_equal '3.2.2'
   end
 end

--- a/redis-rails/Gemfile
+++ b/redis-rails/Gemfile
@@ -3,6 +3,6 @@ gemspec
 
 gem 'redis-store',         '~> 1.1.0', :path => File.expand_path('../../redis-store',         __FILE__)
 gem 'redis-rack',          '~> 1.4.0', :path => File.expand_path('../../redis-rack',          __FILE__)
-gem 'redis-activesupport',    '3.2.1', :path => File.expand_path('../../redis-activesupport', __FILE__)
-gem 'redis-actionpack',       '3.2.1', :path => File.expand_path('../../redis-actionpack',    __FILE__)
+gem 'redis-activesupport',    '3.2.2', :path => File.expand_path('../../redis-activesupport', __FILE__)
+gem 'redis-actionpack',       '3.2.2', :path => File.expand_path('../../redis-actionpack',    __FILE__)
 gem 'SystemTimer', :platform => :mri_18

--- a/redis-rails/lib/redis-rails/version.rb
+++ b/redis-rails/lib/redis-rails/version.rb
@@ -1,5 +1,5 @@
 class Redis
   module Rails
-    VERSION = '3.2.1'
+    VERSION = '3.2.2'
   end
 end

--- a/redis-rails/redis-rails.gemspec
+++ b/redis-rails/redis-rails.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'redis-store',         '~> 1.1.0'
-  s.add_dependency 'redis-activesupport', '~> 3.2.1'
-  s.add_dependency 'redis-actionpack',    '~> 3.2.1'
+  s.add_dependency 'redis-activesupport', '~> 3.2.2'
+  s.add_dependency 'redis-actionpack',    '~> 3.2.2'
 
   s.add_development_dependency 'rake',      '~> 0.9.2.2'
   s.add_development_dependency 'bundler',   '~> 1.1.rc'

--- a/redis-rails/test/redis-rails/version_test.rb
+++ b/redis-rails/test/redis-rails/version_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 describe Redis::Rails::VERSION do
-  it "must be equal to 3.2.1" do
-    Redis::Rails::VERSION.must_equal '3.2.1'
+  it "must be equal to 3.2.2" do
+    Redis::Rails::VERSION.must_equal '3.2.2'
   end
 end


### PR DESCRIPTION
Bumped the versions in redis-actionpack, redis-activesupport, redis-rails and changed the gemspecs to require versions 3.2.2 of actionpack and activesupport. All tests pass.
