### PR TITLE
Allow minor point upgrades of Rails

### DIFF
--- a/redis-rails/Gemfile
+++ b/redis-rails/Gemfile
@@ -2,7 +2,7 @@ source 'http://rubygems.org'
 gemspec
 
 gem 'redis-store',         '~> 1.1.0', :path => File.expand_path('../../redis-store',         __FILE__)
-gem 'redis-activesupport',    '3.1.4', :path => File.expand_path('../../redis-activesupport', __FILE__)
-gem 'redis-actionpack',       '3.1.4', :path => File.expand_path('../../redis-actionpack',    __FILE__)
+gem 'redis-activesupport', '~> 3.1.4', :path => File.expand_path('../../redis-activesupport', __FILE__)
+gem 'redis-actionpack',    '~> 3.1.4', :path => File.expand_path('../../redis-actionpack',    __FILE__)
 gem 'redis-rack',             '1.3.6', :path => File.expand_path('../../redis-rack',          __FILE__)
 gem 'SystemTimer',                     :platform => :mri_18


### PR DESCRIPTION
With the release of Rails 3.1.5 to address two core Rails security vulnerabilities, we needed to upgrade from 3.1.4.  redis-rails blocked this by being tied specifically to 3.1.4.

```
Bundler could not find compatible versions for gem "activesupport":
  In Gemfile:
    redis-rails (~> 3.1.4) ruby depends on
      activesupport (= 3.1.4) ruby

    rails (= 3.1.5) ruby depends on
      activesupport (3.1.5)
```

This pull request adds the ~> operator to the activesupport and actionpack to allow this upgrade.
