### PR TITLE
Issue 128 - Fix entitystore namespace

### DIFF
--- a/redis-rack-cache/lib/rack/cache/redis_entitystore.rb
+++ b/redis-rack-cache/lib/rack/cache/redis_entitystore.rb
@@ -21,7 +21,7 @@ module Rack
 
       class Redis < RedisBase
         def initialize(server, options = {})
-          @cache = ::Redis.new server
+          @cache = ::Redis::Factory.create(server)
         end
 
         def exist?(key)

--- a/redis-rack-cache/test/rack/cache/entitystore/redis_test.rb
+++ b/redis-rack-cache/test/rack/cache/entitystore/redis_test.rb
@@ -29,6 +29,9 @@ describe Rack::Cache::EntityStore::Redis do
     cache = ::Rack::Cache::EntityStore::Redis.resolve(uri("redis://:secret@127.0.0.1")).cache
     cache.id.must_equal("redis://127.0.0.1:6379/0")
     cache.client.password.must_equal('secret')
+    
+    cache = Rack::Cache::MetaStore::Redis.resolve(uri("redis://127.0.0.1:6380/0/entitystore")).cache
+    cache.to_s.must_equal("Redis Client connected to 127.0.0.1:6380 against DB 0 with namespace entitystore")
   end
 
   it 'responds to all required messages' do

--- a/redis-rack-cache/test/rack/cache/metastore/redis_test.rb
+++ b/redis-rack-cache/test/rack/cache/metastore/redis_test.rb
@@ -35,6 +35,9 @@ describe Rack::Cache::MetaStore::Redis do
     cache = Rack::Cache::MetaStore::Redis.resolve(uri("redis://:secret@127.0.0.1")).cache
     cache.id.must_equal("redis://127.0.0.1:6379/0")
     cache.client.password.must_equal('secret')
+    
+    cache = Rack::Cache::MetaStore::Redis.resolve(uri("redis://127.0.0.1:6380/0/metastore")).cache
+    cache.to_s.must_equal("Redis Client connected to 127.0.0.1:6380 against DB 0 with namespace metastore")
   end
 
   # Low-level implementation methods ===========================================


### PR DESCRIPTION
Hi Luca

Everything is in the comment: I fixed the issue with the namespace not being applied for entitystore and added tests for that for both entitystore and metastore. 
Hope you can accept the request, we plan to use it in Production soon soon and I'd prefer having the namespace in place before.

Thanks a lot for the great gem.

Issue 128|fixing entitystore is not namespaced (https://github.com/jodosha/redis-store/issues/128) and adding tests for both metastore and entitystore namespaces

Cheers
Jerome
