### PR TITLE
Override flushdb for namespaced datastore

### DIFF
--- a/redis-store/lib/redis/store/namespace.rb
+++ b/redis-store/lib/redis/store/namespace.rb
@@ -41,6 +41,10 @@ class Redis
         "#{super} with namespace #{@namespace}"
       end
 
+      def flushdb
+        del *keys
+      end
+
       private
         def namespace(key)
           yield interpolate(key)

--- a/redis-store/test/redis/store/namespace_test.rb
+++ b/redis-store/test/redis/store/namespace_test.rb
@@ -23,6 +23,17 @@ describe "Redis::Store::Namespace" do
     @store.send(:interpolate, "#{@namespace}:rabbit").must_equal("#{@namespace}:rabbit")
   end
 
+  it "should ony delete namespaced keys" do
+    other_store = Redis::Store.new
+  
+    other_store.set 'abc', 'cba'
+    @store.set 'def', 'fed'
+
+    @store.flushdb
+    @store.get('def').must_equal(nil)
+    other_store.get('abc').must_equal('cba')
+  end
+
   it "namespaces get"
   it "namespaces set"
   it "namespaces setnx"
@@ -33,7 +44,7 @@ describe "Redis::Store::Namespace" do
   it "namespaces incrby"
   it "namespaces decrby"
   it "namespaces mget"
-
+  
   # it "should namespace get" do
   #   @client.expects(:call).with([:get, "#{@namespace}:rabbit"]).once
   #   @store.get("rabbit")


### PR DESCRIPTION
Hi,

Using Rails 3.2.x and Redis as a cache store with a name space.
When typing `Rails.cache.clear` it flushes the entire datastore instead of on the name spaced keys.
