### PR TITLE
Rescue a "renamed" exception from the redis gem (redis-rb)

### DIFF
--- a/redis-activesupport/lib/active_support/cache/redis_store.rb
+++ b/redis-activesupport/lib/active_support/cache/redis_store.rb
@@ -46,7 +46,7 @@ module ActiveSupport
           matcher = key_matcher(matcher, options)
           begin
             !(keys = @data.keys(matcher)).empty? && @data.del(*keys)
-          rescue Errno::ECONNREFUSED => e
+          rescue Errno::ECONNREFUSED, Redis::CannotConnectError => e
             false
           end
         end
@@ -143,7 +143,7 @@ module ActiveSupport
         def write_entry(key, entry, options)
           method = options && options[:unless_exist] ? :setnx : :set
           @data.send method, key, entry, options
-        rescue Errno::ECONNREFUSED => e
+        rescue Errno::ECONNREFUSED, Redis::CannotConnectError => e
           false
         end
 
@@ -152,7 +152,7 @@ module ActiveSupport
           if entry
             entry.is_a?(ActiveSupport::Cache::Entry) ? entry : ActiveSupport::Cache::Entry.new(entry)
           end
-        rescue Errno::ECONNREFUSED => e
+        rescue Errno::ECONNREFUSED, Redis::CannotConnectError => e
           nil
         end
 
@@ -163,7 +163,7 @@ module ActiveSupport
         #
         def delete_entry(key, options)
           @data.del key
-        rescue Errno::ECONNREFUSED => e
+        rescue Errno::ECONNREFUSED, Redis::CannotConnectError => e
           false
         end
 

--- a/redis-rack/lib/rack/session/redis.rb
+++ b/redis-rack/lib/rack/session/redis.rb
@@ -53,7 +53,7 @@ module Rack
       def with_lock(env, default=nil)
         @mutex.lock if env['rack.multithread']
         yield
-      rescue Errno::ECONNREFUSED
+      rescue Errno::ECONNREFUSED, Redis::CannotConnectError
         if $VERBOSE
           warn "#{self} is unable to find Redis server."
           warn $!.inspect

--- a/redis-rack/lib/rack/session/redis.rb
+++ b/redis-rack/lib/rack/session/redis.rb
@@ -53,7 +53,7 @@ module Rack
       def with_lock(env, default=nil)
         @mutex.lock if env['rack.multithread']
         yield
-      rescue Errno::ECONNREFUSED, Redis::CannotConnectError
+      rescue Errno::ECONNREFUSED, ::Redis::CannotConnectError
         if $VERBOSE
           warn "#{self} is unable to find Redis server."
           warn $!.inspect


### PR DESCRIPTION
In version 3.0 of the redis gem (redis-rb), it changed the exception raised from Errno::ECONNREFUSED to Redis::CannotConnectError. This adds the new exception into the code so that it works properly.

