### PR TITLE
Clean up README files to be more clear and helpful

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
+[![Build Status](https://secure.travis-ci.org/jodosha/redis-store.png?branch=master)](http://travis-ci.org/jodosha/redis-store?branch=master) [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/jodosha/redis-store)
+
 # Redis stores for Ruby frameworks
 
-__Redis Store__ provides a full set of stores (*Cache*, *I18n*, *Session*, *HTTP Cache*) for all the modern Ruby frameworks like: __Ruby on Rails__, __Sinatra__, __Rack__, __Rack::Cache__ and __I18n__. It natively supports object marshalling, timeouts, single or multiple nodes and namespaces.
+__Redis Store__ provides a full set of stores (*Cache*, *I18n*, *Session*, *HTTP Cache*) for modern Ruby frameworks like: __Ruby on Rails__, __Sinatra__, __Rack__, __Rack::Cache__ and __I18n__. It supports object marshalling, timeouts, single or multiple nodes, and namespaces.
 
-Please check the *README* file of each gem, to be informed about the usage.
+Please check the *README* file of each gem for usage and installation guidelines.
 
 ## Redis Installation
 
@@ -16,22 +18,18 @@ MacOS X users should use [Homebrew](https://github.com/mxcl/homebrew) to install
 
 Download and install Redis from [http://redis.io](http://redis.io/)
 
-	wget http://redis.googlecode.com/files/redis-2.4.15.tar.gz
+    wget http://redis.googlecode.com/files/redis-2.4.15.tar.gz
     tar -zxf redis-2.4.15.tar.gz
     mv redis-2.4.15 redis
     cd redis
     make
 
-## Code
-
-[![Build Status](https://secure.travis-ci.org/jodosha/redis-store.png?branch=master)](http://travis-ci.org/jodosha/redis-store?branch=master) [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/jodosha/redis-store)
-
 ## Running tests
 
     git clone git://github.com/jodosha/redis-store.git
-	cd redis-store
-	gem install bundler
-	ruby ci/run.rb
+	  cd redis-store
+	  gem install bundler
+	  ruby ci/run.rb
 
 If you are on **Snow Leopard** you have to run `env ARCHFLAGS="-arch x86_64" ruby ci/run.rb`
 

--- a/redis-actionpack/README.md
+++ b/redis-actionpack/README.md
@@ -1,60 +1,25 @@
 # Redis stores for ActionPack
 
-__`redis-actionpack`__ provides a full set of stores (*Session*, *HTTP Cache*) for __ActionPack__. It natively supports object marshalling, timeouts, single or multiple nodes and namespaces.
+__`redis-actionpack`__ provides a session store for __ActionPack__, specifically for __ActionDispatch__. See the main [redis-store readme](https://github.com/jodosha/redis-store) for general guidelines.
 
-## Redis Installation
-
-### Option 1: Homebrew
-
-MacOS X users should use [Homebrew](https://github.com/mxcl/homebrew) to install Redis:
-
-    brew install redis
-
-### Option 2: From Source
-
-Download and install Redis from [http://redis.io](http://redis.io/)
-
-	wget http://redis.googlecode.com/files/redis-2.4.15.tar.gz
-    tar -zxf redis-2.4.15.tar.gz
-    mv redis-2.4.15 redis
-    cd redis
-    make
-
-## Usage
+## Installation
 
     # Gemfile
-	gem 'redis-actionpack'
+    gem 'redis-actionpack'
 
-### Session Store: Ruby on Rails
+### Usage
 
-    # config/initializers/session_store.rb
-	MyApplication::Application.config.session_store :redis_store
+If you are using redis-store with Rails, consider using the [redis-rails gem](https://github.com/jodosha/redis-store/tree/master/redis-rails) instead. For standalone usage:
 
-### Session Store: Standalone
-
-	ActionController::Base.cache_store = ActionDispatch::Session::RedisSessionStore.new
-
-### HTTP Cache
-
-    # config.ru
-	require 'rack'
-	require 'rack/cache'
-	require 'redis-rack-cache'
-
-	use Rack::Cache,
-	  :metastore   => 'redis://localhost:6379/0/metastore',
-	  :entitystore => 'redis://localhost:6380/0/entitystore'
-
-#### Configuration
-
-For advanced configuration options, please check the [Redis Store Wiki](https://github.com/jodosha/redis-store/wiki).
+    ActionController::Base.cache_store = ActionDispatch::Session::RedisSessionStore.new
 
 ## Running tests
 
+    gem install bundler
     git clone git://github.com/jodosha/redis-store.git
-	cd redis-store/redis-actionpack
-	gem install bundler
-	bundle exec rake
+    cd redis-store/redis-actionpack
+    bundle install
+    bundle exec rake
 
 If you are on **Snow Leopard** you have to run `env ARCHFLAGS="-arch x86_64" bundle exec rake`
 

--- a/redis-activesupport/README.md
+++ b/redis-activesupport/README.md
@@ -1,49 +1,25 @@
 # Redis stores for ActiveSupport
 
-__`redis-activesupport`__ provides a full set of stores (*Cache*) for __ActiveSupport__. It natively supports object marshalling, timeouts, single or multiple nodes and namespaces.
+__`redis-activesupport`__ provides a cache for __ActiveSupport__. See the main [redis-store readme](https://github.com/jodosha/redis-store) for general guidelines.
 
-## Redis Installation
-
-### Option 1: Homebrew
-
-MacOS X users should use [Homebrew](https://github.com/mxcl/homebrew) to install Redis:
-
-    brew install redis
-
-### Option 2: From Source
-
-Download and install Redis from [http://redis.io](http://redis.io/)
-
-	wget http://redis.googlecode.com/files/redis-2.4.15.tar.gz
-    tar -zxf redis-2.4.15.tar.gz
-    mv redis-2.4.15 redis
-    cd redis
-    make
-
-## Usage
+## Installation
 
     # Gemfile
-	gem 'redis-activesupport'
+    gem 'redis-activesupport'
 
-### Cache Store: Ruby on Rails
+### Usage
 
-    # config/environments/production.rb
-	config.cache_store = :redis_store # { ... optional configuration ... }
+If you are using redis-store with Rails, consider using the [redis-rails gem](https://github.com/jodosha/redis-store/tree/master/redis-rails) instead. For standalone usage:
 
-### Cache Store: Standalone
-
-	ActiveSupport::Cache.lookup_store :redis_store # { ... optional configuration ... }
-
-#### Configuration
-
-For advanced configuration options, please check the [Redis Store Wiki](https://github.com/jodosha/redis-store/wiki).
+    ActiveSupport::Cache.lookup_store :redis_store # { ... optional configuration ... }
 
 ## Running tests
 
+    gem install bundler
     git clone git://github.com/jodosha/redis-store.git
-	cd redis-store/redis-activesupport
-	gem install bundler
-	bundle exec rake
+    cd redis-store/redis-activesupport
+    bundle install
+    bundle exec rake
 
 If you are on **Snow Leopard** you have to run `env ARCHFLAGS="-arch x86_64" bundle exec rake`
 

--- a/redis-i18n/README.md
+++ b/redis-i18n/README.md
@@ -1,44 +1,25 @@
 # Redis stores for I18n
 
-__`redis-i18n`__ provides a Redis backend for __I18n__. It natively supports object marshalling, timeouts, single or multiple nodes and namespaces.
+__`redis-i18n`__ provides a Redis backend for __I18n__. See the main [redis-store readme](https://github.com/jodosha/redis-store) for general guidelines.
 
-## Redis Installation
-
-### Option 1: Homebrew
-
-MacOS X users should use [Homebrew](https://github.com/mxcl/homebrew) to install Redis:
-
-    brew install redis
-
-### Option 2: From Source
-
-Download and install Redis from [http://redis.io](http://redis.io/)
-
-	wget http://redis.googlecode.com/files/redis-2.4.15.tar.gz
-    tar -zxf redis-2.4.15.tar.gz
-    mv redis-2.4.15 redis
-    cd redis
-    make
-
-## Usage
+## Installation
 
     # Gemfile
-	gem 'redis-i18n'
+    gem 'redis-i18n'
 
-### Backend:
+### Usage
 
-	I18n.backend = I18n::Backend::Redis.new
+If you are using redis-store with Rails, consider using the [redis-rails gem](https://github.com/jodosha/redis-store/tree/master/redis-rails) instead. For standalone usage:
 
-#### Configuration
-
-For advanced configuration options, please check the [Redis Store Wiki](https://github.com/jodosha/redis-store/wiki).
+    I18n.backend = I18n::Backend::Redis.new
 
 ## Running tests
 
+    gem install bundler
     git clone git://github.com/jodosha/redis-store.git
-	cd redis-store/redis-i18n
-	gem install bundler
-	bundle exec rake
+    cd redis-store/redis-i18n
+    bundle install
+    bundle exec rake
 
 If you are on **Snow Leopard** you have to run `env ARCHFLAGS="-arch x86_64" bundle exec rake`
 

--- a/redis-rack-cache/README.md
+++ b/redis-rack-cache/README.md
@@ -1,51 +1,32 @@
 # Redis stores for Rack::Cache
 
-__`redis-rack-cache`__ provides a Redis backed store for __Rack::Cache__. It natively supports object marshalling, timeouts, single or multiple nodes and namespaces.
+__`redis-rack-cache`__ provides a Redis backed store for __Rack::Cache__, an HTTP cache. See the main [redis-store readme](https://github.com/jodosha/redis-store) for general guidelines.
 
-## Redis Installation
-
-### Option 1: Homebrew
-
-MacOS X users should use [Homebrew](https://github.com/mxcl/homebrew) to install Redis:
-
-    brew install redis
-
-### Option 2: From Source
-
-Download and install Redis from [http://redis.io](http://redis.io/)
-
-	wget http://redis.googlecode.com/files/redis-2.4.15.tar.gz
-    tar -zxf redis-2.4.15.tar.gz
-    mv redis-2.4.15 redis
-    cd redis
-    make
-
-## Usage
+## Installation
 
     # Gemfile
-	gem 'redis-rack-cache'
+    gem 'redis-rack-cache'
 
-### HTTP Cache Store:
+### Usage
+
+If you are using redis-store with Rails, consider using the [redis-rails gem](https://github.com/jodosha/redis-store/tree/master/redis-rails) instead. For standalone usage:
 
     # config.ru
-	require 'rack'
-	require 'rack/cache'
-	require 'redis-rack-cache'
+    require 'rack'
+    require 'rack/cache'
+    require 'redis-rack-cache'
 
-	use Rack::Cache,
-	  :metastore   => 'redis://localhost:6379/0/metastore',
-	  :entitystore => 'redis://localhost:6380/0/entitystore'
-
-#### Configuration
-
-For advanced configuration options, please check the [Redis Store Wiki](https://github.com/jodosha/redis-store/wiki).
+    use Rack::Cache,
+      metastore: 'redis://localhost:6379/0/metastore',
+      entitystore: 'redis://localhost:6380/0/entitystore'
 
 ## Running tests
 
+    gem install bundler
     git clone git://github.com/jodosha/redis-store.git
-	cd redis-store/redis-rack-cache
-	gem install bundler
-	bundle exec rake
+    cd redis-store/redis-rack-cache
+    bundle install
+    bundle exec rake
 
 If you are on **Snow Leopard** you have to run `env ARCHFLAGS="-arch x86_64" bundle exec rake`
 

--- a/redis-rack/README.md
+++ b/redis-rack/README.md
@@ -1,48 +1,29 @@
 # Redis stores for Rack
 
-__`redis-rack`__ provides a Redis backed session store __Rack__. It natively supports object marshalling, timeouts, single or multiple nodes and namespaces.
+__`redis-rack`__ provides a Redis backed session store __Rack__. See the main [redis-store readme](https://github.com/jodosha/redis-store) for general guidelines.
 
-## Redis Installation
-
-### Option 1: Homebrew
-
-MacOS X users should use [Homebrew](https://github.com/mxcl/homebrew) to install Redis:
-
-    brew install redis
-
-### Option 2: From Source
-
-Download and install Redis from [http://redis.io](http://redis.io/)
-
-	wget http://redis.googlecode.com/files/redis-2.4.15.tar.gz
-    tar -zxf redis-2.4.15.tar.gz
-    mv redis-2.4.15 redis
-    cd redis
-    make
-
-## Usage
+## Installation
 
     # Gemfile
-	gem 'redis-rack'
+    gem 'redis-rack'
 
-### Session Store:
+### Usage
+
+If you are using redis-store with Rails, consider using the [redis-rails gem](https://github.com/jodosha/redis-store/tree/master/redis-rails) instead. For standalone usage:
 
     # config.ru
-	require 'rack'
-	require 'rack/session/redis'
+    require 'rack'
+    require 'rack/session/redis'
 
-	use Rack::Session::Redis
-
-#### Configuration
-
-For advanced configuration options, please check the [Redis Store Wiki](https://github.com/jodosha/redis-store/wiki).
+    use Rack::Session::Redis
 
 ## Running tests
 
+    gem install bundler
     git clone git://github.com/jodosha/redis-store.git
-	cd redis-store/redis-rack
-	gem install bundler
-	bundle exec rake
+    cd redis-store/redis-rack
+    bundle install
+    bundle exec rake
 
 If you are on **Snow Leopard** you have to run `env ARCHFLAGS="-arch x86_64" bundle exec rake`
 

--- a/redis-rails/README.md
+++ b/redis-rails/README.md
@@ -1,64 +1,39 @@
 # Redis stores for Ruby on Rails
 
-__`redis-rails`__ provides a full set of stores (*Cache*, *Session*, *HTTP Cache*) for __Ruby on Rails__. It natively supports object marshalling, timeouts, single or multiple nodes and namespaces.
+__`redis-rails`__ provides a full set of stores (*Cache*, *Session*, *HTTP Cache*) for __Ruby on Rails__. See the main [redis-store readme](https://github.com/jodosha/redis-store) for general guidelines.
 
-## Redis Installation
-
-### Option 1: Homebrew
-
-MacOS X users should use [Homebrew](https://github.com/mxcl/homebrew) to install Redis:
-
-    brew install redis
-
-### Option 2: From Source
-
-Download and install Redis from [http://redis.io](http://redis.io/)
-
-	wget http://redis.googlecode.com/files/redis-2.4.15.tar.gz
-    tar -zxf redis-2.4.15.tar.gz
-    mv redis-2.4.15 redis
-    cd redis
-    make
-
-## Usage
+## Installation
 
     # Gemfile
-	gem 'redis-rails'
+    gem 'redis-rails' # Will install several other redis- gems
 
-### Cache Store:
+### Usage
 
-    # config/environments/production.rb
-	config.cache_store = :redis_store # { ... optional configuration ... }
-	# config.cache_store = :redis_store, 'redis://localhost:6379/'
-	# config.cache_store = :redis_store, 'redis://localhost:6379/0' # database 0
-	# config.cache_store = :redis_store, 'redis://localhost:6379/0/cache' # database: 0, namespace: cache
+For Rails 3.2:
 
-### Session Store:
+    # config/application.rb
+    config.cache_store = :redis_store, "redis://localhost:6379/0/cache", { expires_in: 90.minutes }
+
+Configuration values at the end are optional. If you want to use Redis as a backend for sessions, you will also need to set:
 
     # config/initializers/session_store.rb
-	MyApplication::Application.config.session_store :redis_store
+    MyApplication::Application.config.session_store :redis_store
 
-### HTTP Cache
+And if you would like to use Redis as a rack-cache backend for HTTP caching:
 
-    # config.ru
-	require 'rack'
-	require 'rack/cache'
-	require 'redis-rack-cache'
-
-	use Rack::Cache,
-	  :metastore   => 'redis://localhost:6379/0/metastore',
-	  :entitystore => 'redis://localhost:6380/0/entitystore'
-
-#### Configuration
-
-For advanced configuration options, please check the [Redis Store Wiki](https://github.com/jodosha/redis-store/wiki).
+    # config/environments/production.rb
+    config.action_dispatch.rack_cache = {
+      metastore:   "redis://localhost:6379/1/metastore",
+      entitystore: "redis://localhost:6379/1/entitystore"
+    }
 
 ## Running tests
 
+    gem install bundler
     git clone git://github.com/jodosha/redis-store.git
-	cd redis-store/redis-rails
-	gem install bundler
-	bundle exec rake
+    cd redis-store/redis-rails
+    bundle install
+    bundle exec rake
 
 If you are on **Snow Leopard** you have to run `env ARCHFLAGS="-arch x86_64" bundle exec rake`
 

--- a/redis-sinatra/README.md
+++ b/redis-sinatra/README.md
@@ -1,54 +1,33 @@
 # Redis stores for Sinatra
 
-__`redis-sinatra`__ provides a Redis backed cache store for __Sinatra__. It natively supports object marshalling, timeouts, single or multiple nodes and namespaces.
+__`redis-sinatra`__ provides a Redis backed cache store for __Sinatra__. See the main [redis-store readme](https://github.com/jodosha/redis-store) for general guidelines.
 
-## Redis Installation
-
-### Option 1: Homebrew
-
-MacOS X users should use [Homebrew](https://github.com/mxcl/homebrew) to install Redis:
-
-    brew install redis
-
-### Option 2: From Source
-
-Download and install Redis from [http://redis.io](http://redis.io/)
-
-	wget http://redis.googlecode.com/files/redis-2.4.15.tar.gz
-    tar -zxf redis-2.4.15.tar.gz
-    mv redis-2.4.15 redis
-    cd redis
-    make
-
-## Usage
+## Installation
 
     # Gemfile
-	gem 'redis-sinatra'
+    gem 'redis-sinatra'
 
-### Cache Store:
+### Usage
 
-	require 'sinatra'
-	require 'redis-sinatra'
+    require 'sinatra'
+    require 'redis-sinatra'
 
-	class MyApp < Sinatra::Base
-	  register Sinatra::Cache
-	  get "/hi" do
-	    settings.cache.fetch("greet") { "Hello, World!" }
-	  end
-	end
+    class MyApp < Sinatra::Base
+      register Sinatra::Cache
+      get "/hi" do
+        settings.cache.fetch("greet") { "Hello, World!" }
+      end
+    end
 
 Keep in mind that the above fetch will return `"OK"` on success, not the return of the block.
 
-#### Configuration
-
-For advanced configuration options, please check the [Redis Store Wiki](https://github.com/jodosha/redis-store/wiki).
-
 ## Running tests
 
+    gem install bundler
     git clone git://github.com/jodosha/redis-store.git
-	cd redis-store/redis-sinatra
-	gem install bundler
-	bundle exec rake
+    cd redis-store/redis-sinatra
+    bundle install
+    bundle exec rake
 
 If you are on **Snow Leopard** you have to run `env ARCHFLAGS="-arch x86_64" bundle exec rake`
 

--- a/redis-store/README.md
+++ b/redis-store/README.md
@@ -2,32 +2,16 @@
 
 __Redis Store__ provides a full set of stores (*Cache*, *I18n*, *Session*, *HTTP Cache*) for all the modern Ruby frameworks like: __Ruby on Rails__, __Sinatra__, __Rack__, __Rack::Cache__ and __I18n__. It natively supports object marshalling, timeouts, single or multiple nodes and namespaces.
 
-This is the core for all the other gems, please check the *READMEs* to be informed about the usage.
+See the main [redis-store readme](https://github.com/jodosha/redis-store) for general guidelines.
 
-## Redis Installation
-
-### Option 1: Homebrew
-
-MacOS X users should use [Homebrew](https://github.com/mxcl/homebrew) to install Redis:
-
-    brew install redis
-
-### Option 2: From Source
-
-Download and install Redis from [http://redis.io](http://redis.io/)
-
-	wget http://redis.googlecode.com/files/redis-2.4.15.tar.gz
-    tar -zxf redis-2.4.15.tar.gz
-    mv redis-2.4.15 redis
-    cd redis
-    make
+If you are using redis-store with Rails, consider using the [redis-rails gem](https://github.com/jodosha/redis-store/tree/master/redis-rails) instead.
 
 ## Running tests
 
+    gem install bundler
     git clone git://github.com/jodosha/redis-store.git
-	cd redis-store/redis-store
-	gem install bundler
-	ruby ci/run.rb
+    cd redis-store/redis-store
+    ruby ci/run.rb
 
 If you are on **Snow Leopard** you have to run `env ARCHFLAGS="-arch x86_64" ruby ci/run.rb`
 


### PR DESCRIPTION
Howdy!

Great gem, but boy was it frustrating to figure out how to use it. The sub-readme files are confusing, and some of the documentation is just out of date.

This set of changes cleans things up. I've removed links to https://github.com/jodosha/redis-store/wiki/Frameworks-Configuration, which I recommend be removed. It is out of date and confusing. Everything it covers should be covered in the readmes now.
- Move build status to the top of the main readme.
- Move to two-space tabs, like most of the Rails community.
- Drop redis installation instructions from every readme.
- Correct the build instructions. Install before exec.
- Refer users to redis-rails from the individual gems.
- Update the redis-rails readme to be more up-to-date.
- Use Ruby 1.9 conventions for code samples.
