### PR TITLE
Updates redis-store to support dynamic namespaces (when the namespace option is set to a lambda).

### DIFF
--- a/redis-store/lib/redis/store/namespace.rb
+++ b/redis-store/lib/redis/store/namespace.rb
@@ -51,7 +51,11 @@ class Redis
         end
 
         def interpolate(key)
-          key.match(namespace_regexp) ? key : "#{@namespace}:#{key}"
+          key.match(namespace_regexp) ? key : "#{prefix}:#{key}"
+        end
+
+        def prefix
+          @namespace.is_a?(Proc) ? @namespace.call : @namespace
         end
 
         def strip_namespace(key)
@@ -59,7 +63,11 @@ class Redis
         end
 
         def namespace_regexp
-          @namespace_regexp ||= %r{^#{@namespace}\:}
+          if @namespace.is_a?(Proc)
+            %r{^#{prefix}\:}
+          else
+            @namespace_regexp ||= %r{^#{@namespace}\:}
+          end
         end
     end
   end

--- a/redis-store/test/redis/store/namespace_test.rb
+++ b/redis-store/test/redis/store/namespace_test.rb
@@ -23,6 +23,12 @@ describe "Redis::Store::Namespace" do
     @store.send(:interpolate, "#{@namespace}:rabbit").must_equal("#{@namespace}:rabbit")
   end
 
+  it "dynamically namespaces when the namespace is a lambda" do
+    namespace = lambda { "dynamic" }
+    store = Redis::Store.new :namespace => namespace
+    store.send(:interpolate, "rabbit").must_equal("dynamic:rabbit")
+  end
+
   it "should only delete namespaced keys" do
     other_store = Redis::Store.new
 


### PR DESCRIPTION
Hi, 

I ran into an issue where redis-store wasn't properly handling the namespace option if it's set to a lambda. I wrote a test to cover the code change. If you'd like me to approach this fix another way, I'd be happy to, just let me know.

Thanks!
Mike