### PR TITLE
Avoid failing if delete_matched try delete too much data

### DIFF
--- a/redis-activesupport/lib/active_support/cache/redis_store.rb
+++ b/redis-activesupport/lib/active_support/cache/redis_store.rb
@@ -45,7 +45,11 @@ module ActiveSupport
         instrument(:delete_matched, matcher.inspect) do
           matcher = key_matcher(matcher, options)
           begin
-            !(keys = @data.keys(matcher)).empty? && @data.del(*keys)
+            unless (keys = @data.keys(matcher)).empty?
+              keys.each_slice(130_000) do |keys_to_del|
+                @data.del(*keys_to_del)
+              end
+            end
           rescue Errno::ECONNREFUSED => e
             false
           end

--- a/redis-activesupport/test/active_support/cache/redis_store_test.rb
+++ b/redis-activesupport/test/active_support/cache/redis_store_test.rb
@@ -82,6 +82,24 @@ describe ActiveSupport::Cache::RedisStore do
     end
   end
 
+  # in integration way
+  # it "avoid failed if too much key to delete" do
+  #   with_store_management do |store|
+  #     (1..131_100).each do |num|
+  #       store.write "inc-#{num}", num
+  #     end
+  #     store.delete_matched "inc*"
+  #   end
+  # end
+
+  # in unit way
+  it "avoid failed if too much key to delete" do
+    with_store_management do |store|
+      store.instance_variable_get(:@data).stubs(:keys).with("inc*").returns((1..132_000).to_a)
+      store.delete_matched "inc*"
+    end
+  end
+
   it "verifies existence of an object in the store" do
     with_store_management do |store|
       store.exist?("rabbit").must_equal(true)


### PR DESCRIPTION
Ruby cannot accept method with args more than 131_000. To avoid a
StackLevelTooDeep exception, we need limit the number of args pass to
@redis.del(*args)

This case is really an edge but can arrived because, I have this issue in my application sometimes.

An example of code with this failing is do on this gist : https://gist.github.com/4620006