### PR TITLE
cache_store connection url and default options

### DIFF
--- a/redis-activesupport/test/active_support/cache/redis_store_test.rb
+++ b/redis-activesupport/test/active_support/cache/redis_store_test.rb
@@ -27,12 +27,24 @@ describe ActiveSupport::Cache::RedisStore do
     end
   end
 
-  it "writes the data with expiration time" do
-    with_store_management do |store|
-      store.write "rabbit", @white_rabbit, :expires_in => 1.second
-      # store.read("rabbit").must_equal(@white_rabbit)
-      sleep 2
-      store.read("rabbit").must_be_nil
+  describe "expiration time" do
+    it "writes the data with expiration time" do
+      with_store_management do |store|
+        store.write "rabbit", @white_rabbit, :expires_in => 1.second
+        # store.read("rabbit").must_equal(@white_rabbit)
+        sleep 2
+        store.read("rabbit").must_be_nil
+      end
+    end
+
+    it "writes the data with the store default expiration time" do
+      @store = ActiveSupport::Cache::RedisStore.new "redis://127.0.0.1:6379/0", { :expires_in => 1.second }
+
+      with_store_management do |store|
+        store.write "rabbit", @white_rabbit
+        sleep 2
+        store.read("rabbit").must_be_nil
+      end
     end
   end
 

--- a/redis-store/test/redis/factory_test.rb
+++ b/redis-store/test/redis/factory_test.rb
@@ -94,5 +94,14 @@ describe "Redis::Factory" do
         ])
       end
     end
+
+    describe "when given a String with a hash of options" do
+      it "uses specified host, port & db" do
+        store = Redis::Factory.create "redis://127.0.0.1:6380/13", { :expires_in => 1 }
+        store.wont_be_kind_of(Redis::DistributedStore)
+        store.must_be_kind_of(Redis::Store)
+        store.to_s.must_equal("Redis Client connected to 127.0.0.1:6380 against DB 13")
+      end
+    end
   end
 end


### PR DESCRIPTION
The cache_store example with an extra options hash at the end does not seem to work as listed in the example at https://github.com/jodosha/redis-store/blob/master/redis-rails/README.md#cache-store:

```
# config/application.rb
config.cache_store = :redis_store, "redis://localhost:6380/10/cache", { expires_in: 90.minutes }
```

I've added a failing test that shows that when trying to specify a single server with options (e.g. `:expires_in`), it ends up creating a `Redis::DistributedStore` with an additional connection to a non-existent `redis://127.0.0.1:6379`

Relates to #139 & #140. The response there was to use `:servers` / `:redis_server` but that seems to only apply to the Rails session store, not the cache_store.

I've also added another test that shows that the default options to the store (e.g. expires_in) don't get passed down to the write calls when an explicit `:expires_in` option is not given to the write calls. Not sure if this is meant to be supported but the example in the Readme implies it does.

