### PR TITLE
Support Cache Deletion with Pattern Match Strings

### DIFF
--- a/redis-activesupport/README.md
+++ b/redis-activesupport/README.md
@@ -13,6 +13,18 @@ If you are using redis-store with Rails, consider using the [redis-rails gem](ht
 
     ActiveSupport::Cache.lookup_store :redis_store # { ... optional configuration ... }
 
+### Note on Cache Expiring & ActiveSupport::Notifications Subscription
+
+Because you can only delete keys in Redis by referencing to the keys in an explicit manner, It is not possible to use Regex options for your expire_fragment calls ( in ActionController::Caching ) such as:
+
+  `expire_fragment %r{regex-pattern}` 
+
+However, wildcard Redis key matches are supported to expire cache, such as:
+
+  `expire_fragment "rabb*"`
+
+Because of the above, `redis-store` will not fanout any notifications for `cache_delete.active_support` event (as of this writing). All notifications for expiring cache are triggered as `cache_delete_matched.active_support` instrument. And you should be subscribing to this event rather than `cache_delete.active_support` in case you are subscribing to these events in your code at all.
+
 ## Running tests
 
     gem install bundler

--- a/redis-activesupport/lib/active_support/cache/redis_store.rb
+++ b/redis-activesupport/lib/active_support/cache/redis_store.rb
@@ -36,16 +36,30 @@ module ActiveSupport
         end
       end
 
+      # Delete objects for both pattern match and exact match keys
+      # This method is just an alias to delete_matched
+      #
+      # Example:
+      #   cache.delete "rabbit" 
+      #   cache.delete "rabb*"
+      def delete(key, options = nil)
+        options = merged_options(options)
+        instrument(:delete_matched, key.inspect) do |payload|
+          delete_matched(namespaced_key(key, options), options)
+        end
+      end
+
       # Delete objects for matched keys.
       #
       # Example:
-      #   cache.del_matched "rab*"
+      #   cache.delete_matched "rab*"
       def delete_matched(matcher, options = nil)
         options = merged_options(options)
+        matcher = key_matcher(matcher, options)
+        keys = @data.keys(matcher)
         instrument(:delete_matched, matcher.inspect) do
-          matcher = key_matcher(matcher, options)
           begin
-            !(keys = @data.keys(matcher)).empty? && @data.del(*keys)
+            keys.present? && @data.del(*keys)
           rescue Errno::ECONNREFUSED => e
             false
           end

--- a/redis-activesupport/test/active_support/cache/redis_store_test.rb
+++ b/redis-activesupport/test/active_support/cache/redis_store_test.rb
@@ -75,10 +75,24 @@ describe ActiveSupport::Cache::RedisStore do
     end
   end
 
+  it "delete also supports deleting pattern match keys" do
+    with_store_management do |store|
+      store.write "rabbin", "some-foo"
+      
+      store.delete "rabb*"
+      
+      store.read("rabbit").must_be_nil
+      store.read("rabbin").must_be_nil
+    end
+  end
+
   it "deletes matched data" do
     with_store_management do |store|
+      store.write "white-rabbit", @white_rabbit
       store.delete_matched "rabb*"
+      
       store.read("rabbit").must_be_nil
+      store.read("white-rabbit").wont_be_nil
     end
   end
 
@@ -220,8 +234,8 @@ describe ActiveSupport::Cache::RedisStore do
       end
 
       delete = @events.first
-      delete.name.must_equal('cache_delete.active_support')
-      delete.payload.must_equal({ :key => 'the new cardigans' })
+      delete.name.must_equal('cache_delete_matched.active_support')
+      delete.payload.must_equal({ :key => %("the new cardigans") })
     end
 
     it "notifies on #exist?" do


### PR DESCRIPTION
This pull request fixes: #134

As such, it was evident that it's not possible to delete cache objects using `expire_fragment` with first argument as a `Regex` object since we don't support `Regex` arguments for expire_fragment and instead rely on Redis' wildcard pattern match.

```ruby
instrument_fragment_cache :expire_fragment, key do
  if key.is_a?(Regexp)
    cache_store.delete_matched(key, options)
  else
    cache_store.delete(key, options)
  end
end
```

Due to the above behaviour, **delete_matched** was never being invoked and pattern match deletes were not supported.

Since, consumers of redis-store will mostly resort to using wildcard pattern matches and pass in arguments as plain strings, It made sense to have **delete** support both exact match cache deletes and pattern match cache deletes.

This pull request, aliases **delete** to **delete_matched** and supports both pattern match deletes and exact match deletes.

**Note:** I think we should make this clear in the documentation. I'm open to submit any revisions to this pull request as deemed fit by the core contributors.

Another thing that I wanted to point out is that because of the above limitations and reliance on `delete_matched` method for both pattern match deletes and exact match deletes it became difficult to fanout separate notifications for `cache_delete` and `cache_delete_matched` since nested instrument calls ended up firing the innermost instrument event call.

I propose that we support either one of these notifications (my preference: **cache_delete_matched**) and highlight in the documentation that users be careful while subscribing to any such notifications in their code. I've updated the documentation on the same.

I'm open to re-visit this particular piece with notifications as well. I have a few more ideas:

* An initial idea that I had was to determine notification type based on key sizes available in redis. If only 1 key was found, we fanout *cache_delete* notification, if more than 1, we fanout *cache_delete_matched*  But, that is again not a fool proof solution and has some of it's own percussions.

* Another option I thought of was to fire both *cache_delete* and *cache_delete_matched* notifications - which seemed to be the best approach.

I'll leave the last part regarding notifications up in the air and open for discussion and be readily available to submit any pull request revisions in that matter.