### PR TITLE
Specifying default cache options no longer accidentally creates a DistributedStore (Fix for #166)

### DIFF
--- a/redis-activesupport/lib/active_support/cache/redis_store.rb
+++ b/redis-activesupport/lib/active_support/cache/redis_store.rb
@@ -24,8 +24,9 @@ module ActiveSupport
       #   RedisStore.new "localhost:6379/0", "localhost:6380/0"
       #     # => instantiate a cluster
       def initialize(*addresses)
+        options = addresses.extract_options!
         @data = ::Redis::Factory.create(addresses)
-        super(addresses.extract_options!)
+        super(options)
       end
 
       def write(name, value, options = nil)

--- a/redis-activesupport/test/active_support/cache/redis_store_test.rb
+++ b/redis-activesupport/test/active_support/cache/redis_store_test.rb
@@ -14,6 +14,40 @@ describe ActiveSupport::Cache::RedisStore do
     end
   end
 
+  it "creates a normal store when given no addresses" do
+    underlying_store = instantiate_store
+    underlying_store.must_be_instance_of(::Redis::Store)
+  end
+
+  it "creates a normal store when given options only" do
+    underlying_store = instantiate_store(:expires_in => 1.second)
+    underlying_store.must_be_instance_of(::Redis::Store)
+  end
+
+  it "creates a normal store when given a single address" do
+    underlying_store = instantiate_store("redis://127.0.0.1:6380/1")
+    underlying_store.must_be_instance_of(::Redis::Store)
+  end
+
+  it "creates a normal store when given a single address and options" do
+    underlying_store = instantiate_store("redis://127.0.0.1:6380/1",
+                                         { :expires_in => 1.second})
+    underlying_store.must_be_instance_of(::Redis::Store)
+  end
+
+  it "creates a distributed store when given multiple addresses" do
+    underlying_store = instantiate_store("redis://127.0.0.1:6380/1", 
+                                         "redis://127.0.0.1:6381/1")
+    underlying_store.must_be_instance_of(::Redis::DistributedStore)
+  end
+
+  it "creates a distributed store when given multiple address and options" do
+    underlying_store = instantiate_store("redis://127.0.0.1:6380/1",
+                                         "redis://127.0.0.1:6381/1",
+                                         :expires_in => 1.second)
+    underlying_store.must_be_instance_of(::Redis::DistributedStore)
+  end
+
   it "reads the data" do
     with_store_management do |store|
       store.read("rabbit").must_equal(@rabbit)
@@ -278,8 +312,8 @@ describe ActiveSupport::Cache::RedisStore do
   end
 
   private
-    def instantiate_store(addresses = nil)
-      ActiveSupport::Cache::RedisStore.new(addresses).instance_variable_get(:@data)
+    def instantiate_store(*addresses)
+      ActiveSupport::Cache::RedisStore.new(*addresses).instance_variable_get(:@data)
     end
 
     def with_store_management


### PR DESCRIPTION
This pull request includes the failing tests created in #166, along with a fix which makes the tests pass.

This patch causes the options to be extracted from the addresses arguments passed in to `Store#initialize` prior to calling the `Redis::Factory::create` method.