### PR TITLE
Bump the rack dependency to greater than 1.3.6

### DIFF
--- a/redis-rack/redis-rack.gemspec
+++ b/redis-rack/redis-rack.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'redis-store', '~> 1.1.0'
-  s.add_runtime_dependency 'rack',        '~> 1.3.6'
+  s.add_runtime_dependency 'rack',        '>= 1.3.6'
 
   s.add_development_dependency 'rake',      '~> 0.9.2.2'
   s.add_development_dependency 'bundler',   '~> 1.1.rc'


### PR DESCRIPTION
Just bumping the Rack dependency on the Rails 3.1.x branch.
- Sets the Rack dependency to greater than 1.3.6 as it was locked to = 1.3.6
