### PR TITLE
Symmetric encoding

### DIFF
--- a/redis-store/lib/redis/store/marshalling.rb
+++ b/redis-store/lib/redis/store/marshalling.rb
@@ -14,13 +14,13 @@ class Redis
       end
 
       def get(key, options = nil)
-        _unmarshal super(key), options
+        _unmarshal encode(super(encode(key))), options
       end
 
       def mget(*keys)
         options = keys.flatten.pop if keys.flatten.last.is_a?(Hash)
-        super(*keys).map do |result|
-          _unmarshal result, options
+        super(*keys.map{|key| encode(key)}).map do |result|
+          _unmarshal encode(result), options
         end
       end
 
@@ -43,7 +43,11 @@ class Redis
 
         if defined?(Encoding)
           def encode(string)
-            string.to_s.force_encoding(Encoding::BINARY)
+            if string.nil?
+              string
+            else
+              string.to_s.force_encoding(Encoding::BINARY)
+            end
           end
         else
           def encode(string)

--- a/redis-store/test/redis/store/marshalling_test.rb
+++ b/redis-store/test/redis/store/marshalling_test.rb
@@ -123,5 +123,29 @@ describe "Redis::Marshalling" do
       @store.setnx(utf8_key, ascii_string, :raw => true)
       @store.get(utf8_key, :raw => true).bytes.to_a.must_equal(ascii_string.bytes.to_a)
     end
+
+    describe 'time' do
+      require 'time'
+
+      it "marshals time" do
+
+        # This is one of special cases that demonstrates the problem
+        time = Time.utc(2013, 4, 8, 12, 47, 44)
+
+        @store.set('t', time)
+        @store.get('t').must_equal(time)
+      end
+
+      it "unmarshals multiple times" do
+        time = Time.utc(2013, 4, 8, 12, 47, 45)
+        time2 = Time.utc(2013, 4, 8, 12, 47, 44)
+
+        @store.set "t", time
+        @store.set "t2", time2
+        t1, t2 = @store.mget "t", "t2"
+        t1.must_equal(time)
+        t2.must_equal(time2)
+      end
+    end
   end if defined?(Encoding)
 end


### PR DESCRIPTION
Store enforces binary encoding of marshaled strings on set (when possible).
So it must do on retrival.

This is the case of marshaled Time on Rubinius. Some values of Time can not be
unmarshaled from Unicode strings.