### PR TITLE
Run tests against Rails 4 and Ruby 2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,21 @@
+language: ruby
 before_install: gem install bundler
 script: 'ci/run.rb'
 rvm:
   - 1.8.7
   - 1.9.3
-  - rbx
+  - rbx-19mode
+  - rbx-18mode
+  - 2.0.0
 bundler_args: '--path vendor/bundle'
+env:
+  - "RAILS_VERSION=3.2"
+  - "RAILS_VERSION=master"
+
+matrix:
+  allow_failures:
+    - env: "RAILS_VERSION=master"
+    - rvm: 2.0.0
+  exclude:
+    - rvm: 1.8.7
+      env: "RAILS_VERSION=master"

--- a/ci/run.rb
+++ b/ci/run.rb
@@ -13,7 +13,7 @@ GEMS = %w(
 
 builds = GEMS.inject({}) do |result, rubygem|
   Dir.chdir(rubygem) do
-    result[rubygem] = system('bundle update && bundle exec rake')
+    result[rubygem] = system("RAILS_VERSION='#{ENV['RAILS_VERSION']}' bundle update && RAILS_VERSION='#{ENV['RAILS_VERSION']}' bundle exec rake")
   end
 
   result

--- a/redis-actionpack/Gemfile
+++ b/redis-actionpack/Gemfile
@@ -4,3 +4,14 @@ gemspec
 gem 'redis-store', '~> 1.1.0', :path => File.expand_path('../../redis-store', __FILE__)
 gem 'redis-rack',  '~> 1.4.0', :path => File.expand_path('../../redis-rack',  __FILE__)
 gem 'SystemTimer', :platform => :mri_18
+
+version = ENV["RAILS_VERSION"] || "3.2"
+
+rails = case version
+when "master"
+  {:github => "rails/rails"}
+else
+  "~> #{version}.0"
+end
+
+gem "rails", rails

--- a/redis-actionpack/redis-actionpack.gemspec
+++ b/redis-actionpack/redis-actionpack.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'redis-store', '~> 1.1.0'
   s.add_runtime_dependency 'redis-rack',  '~> 1.4.0'
-  s.add_runtime_dependency 'actionpack',  '~> 3.2.3'
+  s.add_runtime_dependency 'actionpack',  '>= 3.2.3'
 
   s.add_development_dependency 'rake',     '~> 10'
   s.add_development_dependency 'bundler',  '~> 1.2'

--- a/redis-activesupport/Gemfile
+++ b/redis-activesupport/Gemfile
@@ -4,3 +4,14 @@ gemspec
 gem 'redis-store', '~> 1.1.0', :path => File.expand_path('../../redis-store', __FILE__)
 gem 'i18n'
 gem 'SystemTimer', :platform => :mri_18
+
+version = ENV["RAILS_VERSION"] || "3.2"
+
+rails = case version
+when "master"
+  {:github => "rails/rails"}
+else
+  "~> #{version}.0"
+end
+
+gem "rails", rails

--- a/redis-activesupport/redis-activesupport.gemspec
+++ b/redis-activesupport/redis-activesupport.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency 'redis-store',   '~> 1.1.0'
-  s.add_runtime_dependency 'activesupport', '~> 3.2.3'
+  s.add_runtime_dependency 'activesupport', '>= 3.2.3'
 
   s.add_development_dependency 'rake',     '~> 10'
   s.add_development_dependency 'bundler',  '~> 1.2'

--- a/redis-rails/Gemfile
+++ b/redis-rails/Gemfile
@@ -6,3 +6,14 @@ gem 'redis-rack',          '~> 1.4.0', :path => File.expand_path('../../redis-ra
 gem 'redis-activesupport',    '3.2.3', :path => File.expand_path('../../redis-activesupport', __FILE__)
 gem 'redis-actionpack',       '3.2.3', :path => File.expand_path('../../redis-actionpack',    __FILE__)
 gem 'SystemTimer', :platform => :mri_18
+
+version = ENV["RAILS_VERSION"] || "3.2"
+
+rails = case version
+when "master"
+  {:github => "rails/rails"}
+else
+  "~> #{version}.0"
+end
+
+gem "rails", rails

--- a/redis-rails/redis-rails.gemspec
+++ b/redis-rails/redis-rails.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'redis-store',         '~> 1.1.0'
-  s.add_dependency 'redis-activesupport', '~> 3.2.3'
-  s.add_dependency 'redis-actionpack',    '~> 3.2.3'
+  s.add_dependency 'redis-activesupport', '>= 3.2.3'
+  s.add_dependency 'redis-actionpack',    '>= 3.2.3'
 
   s.add_development_dependency 'rake',     '~> 10'
   s.add_development_dependency 'bundler',  '~> 1.2'


### PR DESCRIPTION
This doesn't _require_ Rails 4 / Ruby 2.0 to work, as it is on
allow_failures, but at least you can track compatibility.

I did this work because someone has told me that this gem is a blocker for them trying out the Rails 4 RC: https://news.ycombinator.com/item?id=5641560

If I can help you get compatibility with 4 in any way, let me know. It seems like there are a few very small incompatibilities.
