### PR TITLE
sane default ttl, so it does not hog redis

### DIFF
--- a/redis-rack-cache/lib/rack/cache/redis_entitystore.rb
+++ b/redis-rack-cache/lib/rack/cache/redis_entitystore.rb
@@ -36,11 +36,8 @@ module Rack
           buf = StringIO.new
           key, size = slurp(body){|part| buf.write(part) }
 
-          if ttl.zero?
-            [key, size] if cache.set(key, buf.string)
-          else
-            [key, size] if cache.setex(key, ttl, buf.string)
-          end
+          ttl = [RedisRackCache.max_cache_seconds, ttl==0 ? RedisRackCache.max_cache_seconds : ttl].min
+          [key, size] if cache.set(key, buf.string, :expire_in => ttl)
         end
 
         def purge(key)

--- a/redis-rack-cache/lib/rack/cache/redis_metastore.rb
+++ b/redis-rack-cache/lib/rack/cache/redis_metastore.rb
@@ -30,7 +30,7 @@ module Rack
         end
 
         def write(key, entries)
-          cache.set(hexdigest(key), entries)
+          cache.set(hexdigest(key), entries, :expire_in => RedisRackCache.max_cache_seconds)
         end
 
         def purge(key)

--- a/redis-rack-cache/lib/redis-rack-cache.rb
+++ b/redis-rack-cache/lib/redis-rack-cache.rb
@@ -3,3 +3,13 @@ require 'rack/cache'
 require 'rack/cache/redis_entitystore'
 require 'rack/cache/redis_metastore'
 require 'redis-rack-cache/version'
+
+module RedisRackCache
+  def self.max_cache_seconds
+    @max_cache_seconds ||= 60 * 30
+  end
+
+  def self.max_cache_seconds= (val)
+    @max_cache_seconds
+  end
+end


### PR DESCRIPTION
currently there is no default ttl for redis meaning rack cache will hog all of redis, I set up a sane 30 minute default that is tunable 