### PR TITLE
Add ActiveSupport::Cache::RedisStore#expire method and tests

### DIFF
--- a/redis-activesupport/lib/active_support/cache/redis_store.rb
+++ b/redis-activesupport/lib/active_support/cache/redis_store.rb
@@ -123,6 +123,10 @@ module ActiveSupport
         end
       end
 
+      def expire(key, ttl)
+        @data.expire key, ttl
+      end
+
       # Clear all the data from the store.
       def clear
         instrument(:clear, nil, nil) do

--- a/redis-activesupport/test/active_support/cache/redis_store_test.rb
+++ b/redis-activesupport/test/active_support/cache/redis_store_test.rb
@@ -30,8 +30,28 @@ describe ActiveSupport::Cache::RedisStore do
   it "writes the data with expiration time" do
     with_store_management do |store|
       store.write "rabbit", @white_rabbit, :expires_in => 1.second
-      # store.read("rabbit").must_equal(@white_rabbit)
+      store.read("rabbit").must_equal(@white_rabbit)
       sleep 2
+      store.read("rabbit").must_be_nil
+    end
+  end
+
+  it "respects expiration time in seconds" do
+    with_store_management do |store|
+      store.write "rabbit", @white_rabbit
+      store.read("rabbit").must_equal(@white_rabbit)
+      store.expire "rabbit", 1.seconds
+      sleep 2
+      store.read("rabbit").must_be_nil
+    end
+  end
+
+  it "respects expiration time in minutes" do
+    with_store_management do |store|
+      store.write "rabbit", @white_rabbit
+      store.read("rabbit").must_equal(@white_rabbit)
+      store.expire "rabbit", 1.minutes
+      sleep 61
       store.read("rabbit").must_be_nil
     end
   end


### PR DESCRIPTION
I went ahead and added an `expire` method to ActiveSupport::Cache::RedisStore along with corresponding (passing) tests.
