### PR TITLE
Add pluralization support to Redis I18n

### DIFF
--- a/redis-i18n/lib/i18n/backend/redis.rb
+++ b/redis-i18n/lib/i18n/backend/redis.rb
@@ -58,7 +58,25 @@ module I18n
       protected
         def lookup(locale, key, scope = [], options = {})
           key = normalize_flat_keys(locale, key, scope, options[:separator])
-          @store.get "#{locale}.#{key}"
+
+          main_key = "#{locale}.#{key}"
+          if result = @store.get(main_key)
+            return result
+          end
+
+          child_keys = @store.keys("#{main_key}.*")
+          if child_keys.empty?
+            return nil
+          end
+
+          result = { }
+          subkey_part = (main_key.size + 1)..(-1)
+          child_keys.each do |child_key|
+            subkey         = child_key[subkey_part].to_sym
+            result[subkey] = @store.get child_key
+          end
+
+          result
         end
 
         def resolve_link(locale, key)

--- a/redis-i18n/test/i18n/backend/redis_test.rb
+++ b/redis-i18n/test/i18n/backend/redis_test.rb
@@ -21,6 +21,12 @@ describe "I18n::Backend::Redis" do
     I18n.t(:"baz", :scope => :"foo.bar").must_equal(:bang)
   end
 
+  it "gets translations with count" do
+    I18n.backend.store_translations :en, :bar => { :one => :bar, :other => "%{count} bars" }
+    I18n.t(:bar, :count => 1).must_equal(:bar)
+    I18n.t(:bar, :count => 10).must_equal("10 bars")
+  end
+
   it "raises an exception when a proc translation is being saved" do
     lambda {
       I18n.backend.store_translations :en, :foo => lambda {|| }


### PR DESCRIPTION
Changes behavior of I18n::Backend::Redis#lookup. Before it returned
value of "#{locale}.#{key}*" or nil (if the value was not set).

Now it returns value of "#{locale}.#{key}*", if it's missing it returns
hash of sub-keys or nil (if there are none).
