### PR TITLE
Fixes #134 - delete_matched never being called

### DIFF
--- a/redis-activesupport/test/active_support/cache/redis_store/key_name_test.rb
+++ b/redis-activesupport/test/active_support/cache/redis_store/key_name_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+describe ActiveSupport::Cache::RedisStore::KeyName do
+
+  def subject 
+    ActiveSupport::Cache::RedisStore::KeyName
+  end
+
+  it 'matches with start' do 
+    key = subject.new 'foo*baz'
+    key.is_matcher?.must_equal true
+  end
+
+  it 'does not match with star escaped' do 
+    key = subject.new 'foo\*bar'
+    key.is_matcher?.must_equal false
+  end
+
+  it 'does match with question mark' do 
+    key = subject.new 'foo?baz'
+    key.is_matcher?.must_equal true
+  end
+
+  it 'does not match with escaped question mark' do 
+    key = subject.new 'foo\?baz'
+    key.is_matcher?.must_equal false
+  end
+
+  it 'does match with square brackets' do 
+    key = subject.new 'foo[baz]'
+    key.is_matcher?.must_equal true
+  end
+
+  it 'does not match with escaped square brackets' do 
+    key = subject.new 'foo\[baz\]'
+    key.is_matcher?.must_equal false
+  end
+ 
+end

--- a/redis-activesupport/test/active_support/cache/redis_store_test.rb
+++ b/redis-activesupport/test/active_support/cache/redis_store_test.rb
@@ -75,9 +75,9 @@ describe ActiveSupport::Cache::RedisStore do
     end
   end
 
-  it "deletes matched data" do
-    with_store_management do |store|
-      store.delete_matched "rabb*"
+  it "forwards delete to delete_matched if redis matcher is found" do 
+    with_store_management do |store| 
+      store.delete "rabb*" 
       store.read("rabbit").must_be_nil
     end
   end
@@ -234,9 +234,9 @@ describe ActiveSupport::Cache::RedisStore do
       exist.payload.must_equal({ :key => 'the smiths' })
     end
 
-    it "notifies on #delete_matched" do
+    it "notifies with delete_matched if forwarded by delete" do
       with_notifications do
-        @store.delete_matched "afterhours*"
+        @store.delete "afterhours*"
       end
 
       delete_matched = @events.first


### PR DESCRIPTION
This fixes #134. The idea is to raise on delete_matched immediately, and have the `delete` method (the only one actually invoked by activesupport) forward to a clone of delete_matched only if a matching pattern is detected. 

The pattern check may seem a bit naive but it serves the immediate need and may be improved in the future. A new class was introduced to encapsulate any future complexity in the pattern check. 

This implementation mainly differs from other remarkable attempts (i.e. https://github.com/jodosha/redis-store/pull/167/files) because it tries to honour the `delete` and `delete_matched` notifications.