### PR TITLE
Unable to use ActiveSupport::Cache::RedisStore with options

### DIFF
--- a/redis-activesupport/lib/active_support/cache/redis_store.rb
+++ b/redis-activesupport/lib/active_support/cache/redis_store.rb
@@ -24,8 +24,9 @@ module ActiveSupport
       #   RedisStore.new "localhost:6379/0", "localhost:6380/0"
       #     # => instantiate a cluster
       def initialize(*addresses)
+        opts  = addresses.extract_options!
         @data = ::Redis::Store::Factory.create(addresses)
-        super(addresses.extract_options!)
+        super(opts)
       end
 
       def write(name, value, options = nil)

--- a/redis-activesupport/test/active_support/cache/redis_store_test.rb
+++ b/redis-activesupport/test/active_support/cache/redis_store_test.rb
@@ -14,6 +14,12 @@ describe ActiveSupport::Cache::RedisStore do
     end
   end
 
+  it "initializes with options" do
+    store = ActiveSupport::Cache::RedisStore.new "redis://127.0.0.1:6380/1", :compress => true
+    store.instance_variable_get(:@data).must_be_instance_of(Redis::Store)
+    store.options.must_equal({:compress => true})
+  end
+
   it "reads the data" do
     with_store_management do |store|
       store.read("rabbit").must_equal(@rabbit)


### PR DESCRIPTION
Options need to be extracted before they are passed to Factory
