### PR TITLE
use default options when calling pool set to avoid infinite-ttl session leak

### DIFF
--- a/redis-rack/lib/rack/session/redis.rb
+++ b/redis-rack/lib/rack/session/redis.rb
@@ -28,7 +28,7 @@ module Rack
         with_lock(env, [nil, {}]) do
           unless sid and session = @pool.get(sid)
             sid, session = generate_sid, {}
-            unless /^OK/ =~ @pool.set(sid, session)
+            unless /^OK/ =~ @pool.set(sid, session, @default_options)
               raise "Session collision on '#{sid.inspect}'"
             end
           end


### PR DESCRIPTION
Fixes #179 (which see for more detail).
