### PR TITLE
Fix session id locking and implement skip support

### DIFF
--- a/redis-rack/lib/rack/session/redis.rb
+++ b/redis-rack/lib/rack/session/redis.rb
@@ -20,7 +20,7 @@ module Rack
       def generate_unique_sid(session)
         loop do
           sid = generate_sid
-          break sid if [1, 1] == @pool.setnx(sid, session, @default_options)
+          break sid if [1, true].include?([*@pool.setnx(sid, session, @default_options)].first)
         end
       end
 

--- a/redis-rack/lib/rack/session/redis.rb
+++ b/redis-rack/lib/rack/session/redis.rb
@@ -17,20 +17,24 @@ module Rack
         @pool = ::Redis::Store::Factory.create @default_options[:redis_server]
       end
 
-      def generate_unique_sid
+      def generate_unique_sid(session)
         loop do
           sid = generate_sid
-          session = {}
-          break sid, session if [1, 1] == @pool.setnx(sid, session, @default_options)
+          break sid if [1, 1] == @pool.setnx(sid, session, @default_options)
         end
       end
 
       def get_session(env, sid)
-        with_lock(env, [nil, {}]) do
-          unless sid and session = @pool.get(sid)
-            sid, session = generate_unique_sid
+        if env['rack.session.options'][:skip]
+          [generate_sid, {}]
+        else
+          with_lock(env, [nil, {}]) do
+            unless sid and session = @pool.get(sid)
+              session = {}
+              sid = generate_unique_sid(session)
+            end
+            [sid, session]
           end
-          [sid, session]
         end
       end
 


### PR DESCRIPTION
This fixes a couple of issues.

1.) When used inside Rails (with redis-actionpack) the generate_sid method is actually overwritten by the included Compatibility module, so it isn't even used, this uses a different method name to generate a session id to ensure we always call what we expect.

2.) The generate_sid implementation was subject to a race condition, between the GET and SET other worker processes could have also done the same and they would both assume incorrectly that they had a unique session id. Using SETNX we can atomically claim the session id, or generate a new one and try locking that.

3.) If env['rack.session.options'][:skip] = true then we should not even bother with talking to Redis, the session is going to be thrown away, instead we should just return an arbitrary session id and an empty hash. The :skip option was added in Rack 1.4+, which goes along with Rails 3.2+.

