### PR TITLE
Support dynamic (lambda) namespace.

### DIFF
--- a/lib/redis/store/namespace.rb
+++ b/lib/redis/store/namespace.rb
@@ -38,7 +38,7 @@ class Redis
       end
 
       def to_s
-        "#{super} with namespace #{@namespace}"
+        "#{super} with namespace #{namespace_str}"
       end
 
       def flushdb
@@ -50,16 +50,22 @@ class Redis
           yield interpolate(key)
         end
 
-        def interpolate(key)
-          key.match(namespace_regexp) ? key : "#{@namespace}:#{key}"
+        def namespace_str
+          @namespace.is_a?(Proc) ? @namespace.call : @namespace
         end
+
+        def interpolate(key)
+          key.match(namespace_regexp) ? key : "#{namespace_str}:#{key}"
+        end
+
 
         def strip_namespace(key)
           key.gsub namespace_regexp, ""
         end
 
         def namespace_regexp
-          @namespace_regexp ||= %r{^#{@namespace}\:}
+          @namespace_regexps ||= {}
+          @namespace_regexps[namespace_str] ||= %r{^#{namespace_str}\:}
         end
     end
   end

--- a/test/redis/store/namespace_test.rb
+++ b/test/redis/store/namespace_test.rb
@@ -40,6 +40,23 @@ describe "Redis::Store::Namespace" do
     empty_store.keys.must_be_empty
   end
 
+  it "should work with dynamic namespace" do
+    $ns = "ns1"
+    dyn_store = Redis::Store.new :namespace => -> { $ns }
+    dyn_store.set 'key', 'x'
+    $ns = "ns2"
+    dyn_store.set 'key', 'y'
+    $ns = "ns3"
+    dyn_store.set 'key', 'z'
+    dyn_store.flushdb
+    r3 = dyn_store.get 'key'
+    $ns = "ns2"
+    r2 = dyn_store.get 'key'
+    $ns = "ns1"
+    r1 = dyn_store.get 'key'
+    r1.must_equal('x') && r2.must_equal('y') && r3.must_equal(nil)
+  end
+
   it "namespaces get"
   it "namespaces set"
   it "namespaces setnx"


### PR DESCRIPTION
I know this is basically the same as https://github.com/redis-store/redis-store/pull/163 but it turns out I implemented this also. The extra value here are the more robust test and the caching of regex's in a hash instead of compiling them on each call.

In relation to @jodosha's comment about this needing to go into ActiveSupport and not into redis-store, my response is that this is already supported by ActiveSupport but breaks down in redis-store because lack of lambda support in redis-store. I think the patch is fairly clean and will enable lambda namespaces in redis-store in itself and will cause the lambda namespace in ActiveSupport to work correctly.

Specifically a call to a cache clear (flushdb) from ActiveSupport totally breaks down because this isn't supported in redis-store.