### PR TITLE
Backport LoadError fix into 1.0.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,16 @@
-bundler_args: "--without development"
-script: "bundle exec rake"
+language: ruby
+before_install: gem install bundler
+script: 'bundle exec rake'
 rvm:
-  - 1.8.7
-  - 1.9.2
-  - jruby
-  - rbx
+  - 1.9.3
+  - 2.0.0
+  - ruby-head
+  - rbx-19mode
+  - jruby-19mode
+  - jruby-head
+bundler_args: '--path vendor/bundle'
+
+matrix:
+  allow_failures:
+    - rvm: jruby-head
+    - rvm: ruby-head

--- a/README.md
+++ b/README.md
@@ -236,4 +236,4 @@ If you are on **Snow Leopard** you have to run `env ARCHFLAGS="-arch x86_64" bun
 
 ## Copyright
 
-(c) 2009 - 2011 Luca Guidi - [http://lucaguidi.com](http://lucaguidi.com), released under the MIT license
+(c) 2009 - 2013 Luca Guidi - [http://lucaguidi.com](http://lucaguidi.com), released under the MIT license

--- a/lib/redis/store.rb
+++ b/lib/redis/store.rb
@@ -1,3 +1,6 @@
+require 'redis/store/ttl'
+require 'redis/store/interface'
+
 class Redis
   class Store < self
     include Ttl, Interface


### PR DESCRIPTION
This has been done in 'master' and the newer versions of redis-store but not in the 1.0.x branch, which is what's used by default on Rails 2.3.8 and Ruby 1.8.7 (I know, I know....I'm working on the upgrade!)

Anyway, this should fix people's complete inability to use redis-store 1.0.x.