### PR TITLE
Use batched deletes for flushdb with a namespace

### DIFF
--- a/lib/redis/store/namespace.rb
+++ b/lib/redis/store/namespace.rb
@@ -1,6 +1,8 @@
 class Redis
   class Store < self
     module Namespace
+      FLUSHDB_BATCH_SIZE = 1000
+
       def set(key, val, options = nil)
         namespace(key) { |key| super(key, val, options) }
       end
@@ -50,7 +52,7 @@ class Redis
       end
 
       def flushdb
-        del *keys
+        keys.each_slice(FLUSHDB_BATCH_SIZE) { |key_slice| del(*key_slice) }
       end
 
       private


### PR DESCRIPTION
If you have a lot (e.g. 300_000) of keys in a namespace,
Redis::Store#flushdb will abort with an exception:

SystemStackError: stack level too deep

This patch addresses that issue by deleting the namespaced keys in
batches of 1000.