### PR TITLE
Add Ruby 2.1.2 to Travis build matrix, and bump rbx from 1.9 to 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ script: 'bundle exec rake'
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.2
   - ruby-head
-  - rbx-19mode
+  - rbx-2
   - jruby-19mode
   - jruby-head
 bundler_args: '--path vendor/bundle'


### PR DESCRIPTION
Looks like travis builds have been erroring because rbx-19mode is no longer supported. This bumps rbx to 2 and adds Ruby 2.1.2 to the build matrix. 