### PR TITLE
Fixes an issue with using Procs as namespaces

### DIFF
--- a/lib/redis/store/namespace.rb
+++ b/lib/redis/store/namespace.rb
@@ -59,7 +59,11 @@ class Redis
         end
 
         def namespace_regexp
-          @namespace_regexp ||= %r{^#{@namespace}\:}
+          if @namespace.is_a?(Proc)
+            %r{^#{@namespace.call}\:}
+          else
+            @namespace_regexp ||= %r{^#{@namespace}\:}
+          end		
         end
     end
   end


### PR DESCRIPTION
The namespacing code was setup to check if the namespace was already a
part of the key and prepend it if not. The problem was that while
ActiveSupport::Cache::Store and ActiveSupport::Cache::RedisStore support
procs the actual Redis::Store did not. I just added a conditional to
check if the namespace was a proc and use the result if so, otherwise
fallback to the original code. I did not add any tests as much of the
namespace tests were commented out.