### PR TITLE
Prevent options[:namespace] from being set to nil

### DIFF
--- a/lib/redis/store/factory.rb
+++ b/lib/redis/store/factory.rb
@@ -47,7 +47,9 @@ class Redis
 
       def self.normalize_key_names(options)
         options = options.dup
-        options[:namespace] ||= options.delete(:key_prefix) # RailsSessionStore
+        if options.key?(:key_prefix) && !options.key?(:namespace)
+          options[:namespace] = options.delete(:key_prefix) # RailsSessionStore
+        end
         options
       end
 

--- a/test/redis/store/factory_test.rb
+++ b/test/redis/store/factory_test.rb
@@ -129,6 +129,11 @@ describe "Redis::Store::Factory" do
           "Redis Client connected to 127.0.0.1:6380 against DB 0 with namespace theplaylist",
         ])
       end
+
+      it 'instantiates Redis::Store and sets namespace from String' do
+        store = Redis::Store::Factory.create "redis://127.0.0.1:6379/0/theplaylist", { :expire_after => 5 }
+        store.to_s.must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist")
+      end
     end
   end
 end


### PR DESCRIPTION
When using an options Hash, Redis::Store::Factory sets
options[:namespace] to nil if options[:namespace] and
options[:key_prefix] are not defined.
This overrides the namespace defined in the host String.