### PR TITLE
Allow Rails.fetch_multi to work when options are used

### DIFF
--- a/lib/redis/store/namespace.rb
+++ b/lib/redis/store/namespace.rb
@@ -38,10 +38,18 @@ class Redis
       end
 
       def del(*keys)
+        if keys.flatten.last.is_a?(Hash)
+          keys.flatten!
+          options = keys.pop
+        end
         super *keys.map {|key| interpolate(key) } if keys.any?
       end
 
       def mget(*keys)
+        if keys.flatten.last.is_a?(Hash)
+          keys.flatten!
+          options = keys.pop
+        end
         super *keys.map {|key| interpolate(key) } if keys.any?
       end
       

--- a/test/redis/store/namespace_test.rb
+++ b/test/redis/store/namespace_test.rb
@@ -87,6 +87,11 @@ describe "Redis::Store::Namespace" do
        client.expects(:call).with([:del, "#{@namespace}:rabbit", "#{@namespace}:white_rabbit"])
        store.del "rabbit", "white_rabbit"
     end
+    
+    it "should namespace del with multiple keys and work with options" do
+       client.expects(:call).with([:del, "#{@namespace}:rabbit", "#{@namespace}:white_rabbit"])
+       store.del "rabbit", "white_rabbit", raw: true
+    end
 
     it "should namespace keys" do
        store.set "rabbit", @rabbit
@@ -111,6 +116,11 @@ describe "Redis::Store::Namespace" do
     it "should namespace mget" do
        client.expects(:call).with([:mget, "#{@namespace}:rabbit", "#{@namespace}:white_rabbit"])
        store.mget "rabbit", "white_rabbit"
+    end
+    
+    it "should namespace mget keys and work with options" do
+      client.expects(:call).with([:mget, "#{@namespace}:rabbit", "#{@namespace}:white_rabbit"])
+      store.mget "rabbit", "white_rabbit", raw: true
     end
 
     it "should namespace expire" do


### PR DESCRIPTION
When using namespace, calling `mget` or `del` with an options hash causes an exception. Do something similar here to whats in marshalling.rb 