### PR TITLE
factory: Teach to handle ipv6 uri correctly

### DIFF
--- a/lib/redis/store.rb
+++ b/lib/redis/store.rb
@@ -16,7 +16,8 @@ class Redis
     end
 
     def to_s
-      "Redis Client connected to #{@client.host}:#{@client.port} against DB #{@client.db}"
+      h = @client.host
+      "Redis Client connected to #{/:/ =~ h ? '['+h+']' : h}:#{@client.port} against DB #{@client.db}"
     end
 
     private

--- a/lib/redis/store/factory.rb
+++ b/lib/redis/store/factory.rb
@@ -68,7 +68,7 @@ class Redis
                            end
 
         options = {
-          :host     => uri.host,
+          :host     => uri.hostname,
           :port     => uri.port || DEFAULT_PORT, 
           :password => uri.password
         }

--- a/test/redis/store/factory_test.rb
+++ b/test/redis/store/factory_test.rb
@@ -85,6 +85,12 @@ describe "Redis::Store::Factory" do
         store.instance_variable_get(:@client).password.must_equal("secret")
       end
 
+      it "correctly uses specified ipv6 host" do
+        store = Redis::Store::Factory.create "redis://[::1]:6380"
+        store.to_s.must_equal("Redis Client connected to [::1]:6380 against DB 0")
+        store.client.host.must_equal("::1")
+      end
+
       it "instantiates Redis::DistributedStore" do
         store = Redis::Store::Factory.create "redis://127.0.0.1:6379", "redis://127.0.0.1:6380"
         store.must_be_kind_of(Redis::DistributedStore)


### PR DESCRIPTION
For handling ipv6 uris, like e.g.

    redis://[2001:67c:1254:e:89::fa34]:6379

to extract the host, it is required to use uri's .hostname instead of .host:

    irb(main):002:0> u = URI::parse('redis://[2001:67c:1254:e:89::fa34]:6379')
    => #<URI::Generic:0x000000023e6578 URL:redis://[2001:67c:1254:e:89::fa34]:6379>
    irb(main):003:0> u.host
    => "[2001:67c:1254:e:89::fa34]"     # <- NOTE left brackets
    irb(main):004:0> u.hostname
    => "2001:67c:1254:e:89::fa34"

not doing so results in redis client failing this way:

    store = Redis::Store::Factory.create "redis://[::1]:6380"
    puts store

        .../bundle/ruby/2.1.0/gems/redis-3.2.1/lib/redis/connection/ruby.rb:152:in `getaddrinfo': getaddrinfo: Name or service not known (SocketError)
        from /home/kirr/study/rails/redis-store/bundle/ruby/2.1.0/gems/redis-3.2.1/lib/redis/connection/ruby.rb:152:in `connect'
        from /home/kirr/study/rails/redis-store/bundle/ruby/2.1.0/gems/redis-3.2.1/lib/redis/connection/ruby.rb:211:in `connect'
        from /home/kirr/study/rails/redis-store/bundle/ruby/2.1.0/gems/redis-3.2.1/lib/redis/client.rb:322:in `establish_connection'
        from /home/kirr/study/rails/redis-store/bundle/ruby/2.1.0/gems/redis-3.2.1/lib/redis/client.rb:94:in `block in connect'
        from /home/kirr/study/rails/redis-store/bundle/ruby/2.1.0/gems/redis-3.2.1/lib/redis/client.rb:279:in `with_reconnect'
        from /home/kirr/study/rails/redis-store/bundle/ruby/2.1.0/gems/redis-3.2.1/lib/redis/client.rb:93:in `connect'
        from /home/kirr/study/rails/redis-store/bundle/ruby/2.1.0/gems/redis-3.2.1/lib/redis/client.rb:350:in `ensure_connected'
        from /home/kirr/study/rails/redis-store/bundle/ruby/2.1.0/gems/redis-3.2.1/lib/redis/client.rb:207:in `block in process'
        from /home/kirr/study/rails/redis-store/bundle/ruby/2.1.0/gems/redis-3.2.1/lib/redis/client.rb:292:in `logging'
        from /home/kirr/study/rails/redis-store/bundle/ruby/2.1.0/gems/redis-3.2.1/lib/redis/client.rb:206:in `process'
        from /home/kirr/study/rails/redis-store/bundle/ruby/2.1.0/gems/redis-3.2.1/lib/redis/client.rb:112:in `call'
        from /home/kirr/study/rails/redis-store/bundle/ruby/2.1.0/gems/redis-3.2.1/lib/redis.rb:2556:in `block in method_missing'
        from /home/kirr/study/rails/redis-store/bundle/ruby/2.1.0/gems/redis-3.2.1/lib/redis.rb:37:in `block in synchronize'
        from /usr/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
        from /home/kirr/study/rails/redis-store/bundle/ruby/2.1.0/gems/redis-3.2.1/lib/redis.rb:37:in `synchronize'
        from /home/kirr/study/rails/redis-store/bundle/ruby/2.1.0/gems/redis-3.2.1/lib/redis.rb:2555:in `method_missing'
        from test/x.rb:5:in `puts'
        from test/x.rb:5:in `puts'

Fix it.