### PR TITLE
Added redis_version and supports_redis_version? methods to Store and DistributedStore

### DIFF
--- a/lib/redis-store.rb
+++ b/lib/redis-store.rb
@@ -5,6 +5,7 @@ require 'redis/distributed_store'
 require 'redis/store/namespace'
 require 'redis/store/marshalling'
 require 'redis/store/version'
+require 'redis/store/redis_version'
 
 class Redis
   class Store < self

--- a/lib/redis/distributed_store.rb
+++ b/lib/redis/distributed_store.rb
@@ -34,6 +34,18 @@ class Redis
       node_for(key).setnx(key, value, options)
     end
 
+    def redis_version
+      nodes.first.redis_version unless nodes.empty?
+    end
+
+    def supports_redis_version?(version)
+      if nodes.empty?
+        false
+      else
+        nodes.first.supports_redis_version?(version)
+      end
+    end
+
     private
       def _extend_namespace(options)
         @namespace = options[:namespace]

--- a/lib/redis/store.rb
+++ b/lib/redis/store.rb
@@ -1,9 +1,10 @@
 require 'redis/store/ttl'
 require 'redis/store/interface'
+require 'redis/store/redis_version'
 
 class Redis
   class Store < self
-    include Ttl, Interface
+    include Ttl, Interface, RedisVersion
 
     def initialize(options = { })
       super

--- a/lib/redis/store/redis_version.rb
+++ b/lib/redis/store/redis_version.rb
@@ -1,0 +1,14 @@
+class Redis
+  class Store < self
+    module RedisVersion
+      def redis_version
+        info('server')['redis_version']
+      end
+
+      def supports_redis_version?(version)
+        (redis_version.split(".").map(&:to_i) <=> version.split(".").map(&:to_i)) >= 0
+      end
+    end
+  end
+end
+

--- a/test/redis/distributed_store_test.rb
+++ b/test/redis/distributed_store_test.rb
@@ -39,6 +39,20 @@ describe "Redis::DistributedStore" do
     @dmr.get("rabbit").must_equal(@rabbit)
   end
 
+  describe '#redis_version' do
+    it 'returns redis version' do
+      @dmr.nodes.first.expects(:redis_version)
+      @dmr.redis_version
+    end
+  end
+
+  describe '#supports_redis_version?' do
+    it 'returns redis version' do
+      @dmr.nodes.first.expects(:supports_redis_version?).with('2.8.0')
+      @dmr.supports_redis_version?('2.8.0')
+    end
+  end
+
   describe "namespace" do
     it "uses namespaced key" do
       @dmr = Redis::DistributedStore.new [

--- a/test/redis/store/redis_version_test.rb
+++ b/test/redis/store/redis_version_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+describe "Redis::RedisVersion" do
+  def setup
+    @store  = Redis::Store.new
+  end
+
+  def teardown
+    @store.quit
+  end
+
+  describe '#redis_version' do
+    it 'returns redis version' do
+      @store.redis_version.to_s.must_match(/^\d{1}\.\d{1}\.\d{1}$/)
+    end
+  end
+
+  describe '#supports_redis_version?' do
+    it 'returns true if redis version is greater or equal to required version' do
+      @store.stubs(:redis_version).returns('2.8.9')
+      @store.supports_redis_version?('2.8.0').must_equal(true)
+      @store.supports_redis_version?('2.8.9').must_equal(true)
+      @store.supports_redis_version?('2.9.0').must_equal(false)
+      @store.supports_redis_version?('3.0.0').must_equal(false)
+    end
+  end
+end
+

--- a/test/redis/store/redis_version_test.rb
+++ b/test/redis/store/redis_version_test.rb
@@ -11,15 +11,16 @@ describe "Redis::RedisVersion" do
 
   describe '#redis_version' do
     it 'returns redis version' do
-      @store.redis_version.to_s.must_match(/^\d{1}\.\d{1}\.\d{1}$/)
+      @store.redis_version.to_s.must_match(/^\d{1}\.\d{1,}\.\d{1,}$/)
     end
   end
 
   describe '#supports_redis_version?' do
     it 'returns true if redis version is greater or equal to required version' do
-      @store.stubs(:redis_version).returns('2.8.9')
-      @store.supports_redis_version?('2.8.0').must_equal(true)
-      @store.supports_redis_version?('2.8.9').must_equal(true)
+      @store.stubs(:redis_version).returns('2.8.19')
+      @store.supports_redis_version?('2.6.0').must_equal(true)
+      @store.supports_redis_version?('2.8.19').must_equal(true)
+      @store.supports_redis_version?('2.8.20').must_equal(false)
       @store.supports_redis_version?('2.9.0').must_equal(false)
       @store.supports_redis_version?('3.0.0').must_equal(false)
     end


### PR DESCRIPTION
Helper methods to determine version of Redis server for implementing version-specific improvements e.g using SCAN instead of KEYS for matched deletes as in redis-store/redis-activesupport#35