### PR TITLE
Bump to 1.1.7

### DIFF
--- a/test/redis/store/version_test.rb
+++ b/test/redis/store/version_test.rb
@@ -2,6 +2,6 @@ require 'test_helper'
 
 describe Redis::Store::VERSION do
   it 'returns current version' do
-    Redis::Store::VERSION.must_equal '1.1.6'
+    Redis::Store::VERSION.must_equal '1.1.7'
   end
 end


### PR DESCRIPTION
It was resolved because the version_test.rb had fallen.