### PR TITLE
bump rbx 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.1
   - 2.2
   - ruby-head
-  - rbx-19mode
+  - rbx-2
   - jruby-19mode
   - jruby-head
 bundler_args: '--path vendor/bundle'


### PR DESCRIPTION

see : https://docs.travis-ci.com/user/languages/ruby/

Note that the syntax of rbx-19mode isn’t supported anymore, becouse use rbx2