### PR TITLE
Set :raw => true if marshalling

### DIFF
--- a/lib/redis/store/factory.rb
+++ b/lib/redis/store/factory.rb
@@ -50,6 +50,7 @@ class Redis
         if options.key?(:key_prefix) && !options.key?(:namespace)
           options[:namespace] = options.delete(:key_prefix) # RailsSessionStore
         end
+        options[:raw] = !options[:marshalling]
         options
       end
 

--- a/test/redis/store/factory_test.rb
+++ b/test/redis/store/factory_test.rb
@@ -44,6 +44,7 @@ describe "Redis::Store::Factory" do
       it "allows/disable marshalling" do
         store = Redis::Store::Factory.create :marshalling => false
         store.instance_variable_get(:@marshalling).must_equal(false)
+        store.instance_variable_get(:@options)[:raw].must_equal(true)
       end
 
       it "should instantiate a Redis::DistributedStore store" do


### PR DESCRIPTION
Fixes #253 and resolves hard-to-debug marshalling errors when `raw: true`
is not set on the read() call, since increment() will set `raw: true` by
default.

Shoutouts to @netoneko for getting this working initially.