### PR TITLE
Change test for version

### DIFF
--- a/test/redis/store/version_test.rb
+++ b/test/redis/store/version_test.rb
@@ -2,6 +2,6 @@ require 'test_helper'
 
 describe Redis::Store::VERSION do
   it 'returns current version' do
-    Redis::Store::VERSION.must_equal '1.1.7'
+    Redis::Store::VERSION.wont_equal nil
   end
 end


### PR DESCRIPTION
Changes the test for `Redis::Store::VERSION` so we keep code coverage up and it doesn't break every time we release a tag. The library should definitely have a `VERSION` constant for the gemspec, but it shouldn't be dependent on a specific value of that constant in order for tests to pass.