### PR TITLE
Add support for marshalling mset

### DIFF
--- a/lib/redis/store/marshalling.rb
+++ b/lib/redis/store/marshalling.rb
@@ -24,6 +24,16 @@ class Redis
         end
       end
 
+      def mset(*args)
+        options = args.pop if args.length.odd?
+        updates = []
+        args.each_slice(2) do |(key, value)|
+          updates << encode(key)
+          _marshal(value, options) { |v| updates << encode(v) }
+        end
+        super(*updates)
+      end
+
       private
         def _marshal(val, options)
           yield marshal?(options) ? Marshal.dump(val) : val

--- a/test/redis/store/marshalling_test.rb
+++ b/test/redis/store/marshalling_test.rb
@@ -23,6 +23,12 @@ describe "Redis::Marshalling" do
     @store.get("rabbit").must_equal(@white_rabbit)
   end
 
+  it "marshals on multi set" do
+    @store.mset("rabbit", @white_rabbit, "rabbit2", @rabbit)
+    @store.get("rabbit").must_equal(@white_rabbit)
+    @store.get("rabbit2").must_equal(@rabbit)
+  end
+
   if RUBY_VERSION.match /1\.9/
     it "doesn't unmarshal on get if raw option is true" do
       @store.get("rabbit", :raw => true).must_equal("\x04\bU:\x0FOpenStruct{\x06:\tnameI\"\nbunny\x06:\x06EF")
@@ -36,6 +42,12 @@ describe "Redis::Marshalling" do
   it "doesn't marshal set if raw option is true" do
     @store.set "rabbit", @white_rabbit, :raw => true
     @store.get("rabbit", :raw => true).must_equal(%(#<OpenStruct color="white">))
+  end
+
+  it "doesn't marshal multi set if raw option is true" do
+    @store.mset("rabbit", @white_rabbit, "rabbit2", @rabbit, :raw => true)
+    @store.get("rabbit", :raw => true).must_equal(%(#<OpenStruct color="white">))
+    @store.get("rabbit2", :raw => true).must_equal(%(#<OpenStruct name="bunny">))
   end
 
   it "doesn't unmarshal if get returns an empty string" do


### PR DESCRIPTION
While attempting to speed up some particularly heavy caching in an app, I tried to use `mset` via **redis-store**. It worked great up until I attempted to retrieve the values I set. I received some error messaging similar to #227. After a few minutes of head-scratching, I realized that I wasn't looking at a bug, but rather that **redis-store** doesn't support marshalling values passed through `mset`. This pull requests add support for that.

I didn't see a guide for contributions, so please let me know if anything can be improved here. Note: Since `mget` hadn't been added to`Redis::Store::Interface`, I didn't add `mset` either.