### PR TITLE
Forward new Hash, not nil, when options are unset

### DIFF
--- a/lib/redis/store/namespace.rb
+++ b/lib/redis/store/namespace.rb
@@ -44,7 +44,7 @@ class Redis
       end
 
       def mget(*keys)
-        options = keys.pop if keys.last.is_a? Hash
+        options = (keys.pop if keys.last.is_a? Hash) || {}
         if keys.any?
           # Marshalling gets extended before Namespace does, so we need to pass options further
           if singleton_class.ancestors.include? Marshalling

--- a/test/redis/store/marshalling_test.rb
+++ b/test/redis/store/marshalling_test.rb
@@ -99,7 +99,9 @@ describe "Redis::Marshalling" do
 
   it "doesn't unmarshal on multi get" do
     @store.set "rabbit2", @white_rabbit
-    rabbit, rabbit2 = @store.mget "rabbit", "rabbit2"
+    rabbits = @store.mget "rabbit", "rabbit2"
+    rabbit, rabbit2 = rabbits
+    rabbits.length.must_equal(2)
     rabbit.must_equal(@rabbit)
     rabbit2.must_equal(@white_rabbit)
   end


### PR DESCRIPTION
While testing #269 , I discovered that `mget` returns one more result than expected in some situations. When `Marshalling` and `Namespace` are both in play, `mget` in `Namespace` will forward any options to `mget` in `Marshalling`.

Starting [here](https://github.com/tvjg/redis-store/blob/mget-namespace-nil-options/lib/redis/store/namespace.rb#L46).

```ruby
options = keys.pop if keys.last.is_a? Hash
```

Then a few lines later:

```ruby
super(*keys.map {|key| interpolate(key) }, options)
```

If no options were passed, then effectively you get something like:

```ruby
super(key1, key2, key3, nil)
```

`mget` in `Marshalling` makes the same check again.

```ruby
options = keys.pop if keys.last.is_a?(Hash)
```

The last value in the collection will be `nil` which fails the `is_a?` check and, thus, is left in the `keys` array and passed to the underlying `mget` call.

There are probably a few ways to fix this, but it seemed easiest to ensure that we always pass a new, empty options hash if one was not provided. I also added a test assertion to ensure that the result count was correct. The use of destructuring there masked the problem. Please let me know if further adjustments are needed.