### PR TITLE
Add RuboCop and correct/ignore offenses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 Gemfile.lock
 *.gem
 tmp/
+.bundle
+stdout

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,45 @@
+# Configuration parameters: AllowSafeAssignment.
+Lint/AssignmentInCondition:
+  Exclude:
+    - 'lib/redis/store/ttl.rb'
+
+# Configuration parameters: AllowHeredoc, AllowURI, URISchemes.
+# URISchemes: http, https
+Metrics/LineLength:
+  Max: 128
+
+Style/ClassVars:
+  Exclude:
+    - 'lib/redis/distributed_store.rb'
+
+# TODO: Write documentation in a different branch.
+Style/Documentation:
+  Exclude:
+    - 'spec/**/*'
+    - 'test/**/*'
+    - 'lib/redis/distributed_store.rb'
+    - 'lib/redis/store.rb'
+    - 'lib/redis/store/factory.rb'
+    - 'lib/redis/store/interface.rb'
+    - 'lib/redis/store/marshalling.rb'
+    - 'lib/redis/store/namespace.rb'
+    - 'lib/redis/store/redis_version.rb'
+    - 'lib/redis/store/ttl.rb'
+
+# Configuration parameters: ExpectMatchingDefinition, Regex, IgnoreExecutableScripts.
+Style/FileName:
+  Exclude:
+    - 'lib/redis-store.rb'
+
+# Configuration parameters: AllowedVariables.
+Style/GlobalVars:
+  Exclude:
+    - 'test/redis/store/namespace_test.rb'
+
+# Configuration parameters: NamePrefix, NamePrefixBlacklist, NameWhitelist.
+# NamePrefix: is_, has_, have_
+# NamePrefixBlacklist: is_, has_, have_
+# NameWhitelist: is_a?
+Style/PredicateName:
+  Exclude:
+    - 'test/redis/store/ttl_test.rb'

--- a/Rakefile
+++ b/Rakefile
@@ -2,3 +2,6 @@ require 'bundler/setup'
 require 'rake'
 require 'bundler/gem_tasks'
 require 'redis-store/testing/tasks'
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new :lint

--- a/lib/redis/distributed_store.rb
+++ b/lib/redis/distributed_store.rb
@@ -5,7 +5,7 @@ class Redis
     @@timeout = 5
     attr_reader :ring
 
-    def initialize(addresses, options = { })
+    def initialize(addresses, options = {})
       nodes = addresses.map do |address|
         ::Redis::Store.new _merge_options(address, options)
       end
@@ -19,7 +19,7 @@ class Redis
     end
 
     def reconnect
-      nodes.each {|node| node.reconnect }
+      nodes.each(&:reconnect)
     end
 
     def set(key, value, options = nil)
@@ -51,16 +51,15 @@ class Redis
     end
 
     private
-      def _extend_namespace(options)
-        @namespace = options[:namespace]
-        extend ::Redis::Store::Namespace if @namespace
-      end
 
-      def _merge_options(address, options)
-        address.merge({
-          :timeout => options[:timeout] || @@timeout, 
-          :namespace => options[:namespace]
-        })
-      end
+    def _extend_namespace(options)
+      @namespace = options[:namespace]
+      extend ::Redis::Store::Namespace if @namespace
+    end
+
+    def _merge_options(address, options)
+      address.merge(timeout: options[:timeout] || @@timeout,
+                    namespace: options[:namespace])
+    end
   end
 end

--- a/lib/redis/store.rb
+++ b/lib/redis/store.rb
@@ -6,7 +6,7 @@ class Redis
   class Store < self
     include Ttl, Interface, RedisVersion
 
-    def initialize(options = { })
+    def initialize(options = {})
       super
       _extend_marshalling options
       _extend_namespace   options
@@ -18,19 +18,19 @@ class Redis
 
     def to_s
       h = @client.host
-      "Redis Client connected to #{/:/ =~ h ? '['+h+']' : h}:#{@client.port} against DB #{@client.db}"
+      "Redis Client connected to #{/:/ =~ h ? '[' + h + ']' : h}:#{@client.port} against DB #{@client.db}"
     end
 
     private
-      def _extend_marshalling(options)
-        @marshalling = !(options[:marshalling] === false) # HACK - TODO delegate to Factory
-        extend Marshalling if @marshalling
-      end
 
-      def _extend_namespace(options)
-        @namespace = options[:namespace]
-        extend Namespace
-      end
+    def _extend_marshalling(options)
+      @marshalling = !(options[:marshalling] == false) # HACK: - TODO delegate to Factory
+      extend Marshalling if @marshalling
+    end
+
+    def _extend_namespace(options)
+      @namespace = options[:namespace]
+      extend Namespace
+    end
   end
 end
-

--- a/lib/redis/store/factory.rb
+++ b/lib/redis/store/factory.rb
@@ -3,7 +3,6 @@ require 'uri'
 class Redis
   class Store < self
     class Factory
-
       DEFAULT_PORT = 6379
 
       def self.create(*options)
@@ -17,10 +16,8 @@ class Redis
       end
 
       def create
-        if @addresses.empty?
-          @addresses << {}
-        end
-        
+        @addresses << {} if @addresses.empty?
+
         if @addresses.size > 1
           ::Redis::DistributedStore.new @addresses, @options
         else
@@ -38,11 +35,7 @@ class Redis
 
       def self.extract_host_options_from_hash(options)
         options = normalize_key_names(options)
-        if host_options?(options)
-          options
-        else
-          nil 
-        end
+        options if host_options?(options)
       end
 
       def self.normalize_key_names(options)
@@ -55,23 +48,17 @@ class Redis
       end
 
       def self.host_options?(options)
-        if options.keys.any? {|n| [:host, :db, :port].include?(n) }
-          options
-        else
-          nil # just to be clear
-        end
+        options if options.keys.any? { |n| [:host, :db, :port].include?(n) }
       end
 
       def self.extract_host_options_from_uri(uri)
         uri = URI.parse(uri)
-        _, db, namespace = if uri.path
-                             uri.path.split(/\//)
-                           end
+        _, db, namespace = (uri.path.split(%r{\/}) if uri.path)
 
         options = {
-          :host     => uri.hostname,
-          :port     => uri.port || DEFAULT_PORT, 
-          :password => uri.password
+          host: uri.hostname,
+          port: uri.port || DEFAULT_PORT,
+          password: uri.password
         }
 
         options[:db]        = db.to_i   if db
@@ -83,7 +70,7 @@ class Redis
       private
 
       def extract_addresses_and_options(*options)
-        options.flatten.compact.each do |token| 
+        options.flatten.compact.each do |token|
           resolved = self.class.resolve(token)
           if resolved
             @addresses << resolved
@@ -92,7 +79,6 @@ class Redis
           end
         end
       end
-
     end
   end
 end

--- a/lib/redis/store/interface.rb
+++ b/lib/redis/store/interface.rb
@@ -1,7 +1,7 @@
 class Redis
   class Store < self
     module Interface
-      def get(key, options = nil)
+      def get(key, _options = nil)
         super(key)
       end
 
@@ -9,11 +9,11 @@ class Redis
         super(key, value, options || {})
       end
 
-      def setnx(key, value, options = nil)
+      def setnx(key, value, _options = nil)
         super(key, value)
       end
 
-      def setex(key, expiry, value, options = nil)
+      def setex(key, expiry, value, _options = nil)
         super(key, expiry, value)
       end
     end

--- a/lib/redis/store/marshalling.rb
+++ b/lib/redis/store/marshalling.rb
@@ -35,32 +35,33 @@ class Redis
       end
 
       private
-        def _marshal(val, options)
-          yield marshal?(options) ? Marshal.dump(val) : val
-        end
 
-        def _unmarshal(val, options)
-          unmarshal?(val, options) ? Marshal.load(val) : val
-        end
+      def _marshal(val, options)
+        yield marshal?(options) ? Marshal.dump(val) : val
+      end
 
-        def marshal?(options)
-          !(options && options[:raw])
-        end
+      def _unmarshal(val, options)
+        unmarshal?(val, options) ? Marshal.load(val) : val
+      end
 
-        def unmarshal?(result, options)
-          result && result.size > 0 && marshal?(options)
-        end
+      def marshal?(options)
+        !(options && options[:raw])
+      end
 
-        if defined?(Encoding)
-          def encode(string)
-            key = string.to_s.dup
-            key.force_encoding(Encoding::BINARY)
-          end
-        else
-          def encode(string)
-            string
-          end
+      def unmarshal?(result, options)
+        result && !result.empty? && marshal?(options)
+      end
+
+      if defined?(Encoding)
+        def encode(string)
+          key = string.to_s.dup
+          key.force_encoding(Encoding::BINARY)
         end
+      else
+        def encode(string)
+          string
+        end
+      end
     end
   end
 end

--- a/lib/redis/store/namespace.rb
+++ b/lib/redis/store/namespace.rb
@@ -15,7 +15,7 @@ class Redis
         namespace(key) { |k| super(k, val, options) }
       end
 
-      def ttl(key, options = nil)
+      def ttl(key, _options = nil)
         namespace(key) { |k| super(k) }
       end
 
@@ -35,28 +35,27 @@ class Redis
         namespace(key) { |k| super(k, increment) }
       end
 
-      def keys(pattern = "*")
-        namespace(pattern) { |p| super(p).map{|key| strip_namespace(key) } }
+      def keys(pattern = '*')
+        namespace(pattern) { |p| super(p).map { |key| strip_namespace(key) } }
       end
 
       def del(*keys)
-        super(*keys.map {|key| interpolate(key) }) if keys.any?
+        super(*keys.map { |key| interpolate(key) }) if keys.any?
       end
 
       def mget(*keys)
         options = (keys.pop if keys.last.is_a? Hash) || {}
-        if keys.any?
-          # Marshalling gets extended before Namespace does, so we need to pass options further
-          if singleton_class.ancestors.include? Marshalling
-            super(*keys.map {|key| interpolate(key) }, options)
-          else
-            super(*keys.map {|key| interpolate(key) })
-          end
+        return unless keys.any?
+        # Marshalling gets extended before Namespace does, so we need to pass options further
+        if singleton_class.ancestors.include? Marshalling
+          super(*keys.map { |key| interpolate(key) }, options)
+        else
+          super(*keys.map { |key| interpolate(key) })
         end
       end
 
       def expire(key, ttl)
-         namespace(key) { |k| super(k, ttl) }
+        namespace(key) { |k| super(k, ttl) }
       end
 
       def to_s
@@ -80,28 +79,29 @@ class Redis
       end
 
       private
-        def namespace(key)
-          yield interpolate(key)
-        end
 
-        def namespace_str
-          @namespace.is_a?(Proc) ? @namespace.call : @namespace
-        end
+      def namespace(key)
+        yield interpolate(key)
+      end
 
-        def interpolate(key)
-          return key unless namespace_str
-          key.match(namespace_regexp) ? key : "#{namespace_str}:#{key}"
-        end
+      def namespace_str
+        @namespace.is_a?(Proc) ? @namespace.call : @namespace
+      end
 
-        def strip_namespace(key)
-          return key unless namespace_str
-          key.gsub namespace_regexp, ""
-        end
+      def interpolate(key)
+        return key unless namespace_str
+        key.match(namespace_regexp) ? key : "#{namespace_str}:#{key}"
+      end
 
-        def namespace_regexp
-          @namespace_regexps ||= {}
-          @namespace_regexps[namespace_str] ||= %r{^#{namespace_str}\:}
-        end
+      def strip_namespace(key)
+        return key unless namespace_str
+        key.gsub namespace_regexp, ''
+      end
+
+      def namespace_regexp
+        @namespace_regexps ||= {}
+        @namespace_regexps[namespace_str] ||= /^#{namespace_str}\:/
+      end
     end
   end
 end

--- a/lib/redis/store/redis_version.rb
+++ b/lib/redis/store/redis_version.rb
@@ -6,9 +6,8 @@ class Redis
       end
 
       def supports_redis_version?(version)
-        (redis_version.split(".").map(&:to_i) <=> version.split(".").map(&:to_i)) >= 0
+        (redis_version.split('.').map(&:to_i) <=> version.split('.').map(&:to_i)) >= 0
       end
     end
   end
 end
-

--- a/lib/redis/store/ttl.rb
+++ b/lib/redis/store/ttl.rb
@@ -3,7 +3,7 @@ class Redis
     module Ttl
       def set(key, value, options = nil)
         if ttl = expires_in(options)
-          setex(key, ttl.to_i, value, :raw => true)
+          setex(key, ttl.to_i, value, raw: true)
         else
           super(key, value, options)
         end
@@ -18,20 +18,21 @@ class Redis
       end
 
       protected
-        def setnx_with_expire(key, value, ttl)
-          multi do
-            setnx(key, value, :raw => true)
-            expire(key, ttl)
-          end
+
+      def setnx_with_expire(key, value, ttl)
+        multi do
+          setnx(key, value, raw: true)
+          expire(key, ttl)
         end
+      end
 
       private
-        def expires_in(options)
-          if options
-            # Rack::Session           Merb                    Rails/Sinatra
-            options[:expire_after] || options[:expires_in] || options[:expire_in]
-          end
-        end
+
+      def expires_in(options)
+        return unless options
+        # Rack::Session           Merb                    Rails/Sinatra
+        options[:expire_after] || options[:expires_in] || options[:expire_in]
+      end
     end
   end
 end

--- a/lib/redis/store/version.rb
+++ b/lib/redis/store/version.rb
@@ -1,5 +1,5 @@
 class Redis
   class Store < self
-    VERSION = '1.2.0'
+    VERSION = '1.2.0'.freeze
   end
 end

--- a/redis-store.gemspec
+++ b/redis-store.gemspec
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path('../lib', __FILE__)
+$LOAD_PATH.push File.expand_path('../lib', __FILE__)
 require 'redis/store/version'
 
 Gem::Specification.new do |s|
@@ -8,15 +8,15 @@ Gem::Specification.new do |s|
   s.authors     = ['Luca Guidi']
   s.email       = ['me@lucaguidi.com']
   s.homepage    = 'http://redis-store.org/redis-store'
-  s.summary     = %q{Redis stores for Ruby frameworks}
-  s.description = %q{Namespaced Rack::Session, Rack::Cache, I18n and cache Redis stores for Ruby web frameworks.}
+  s.summary     = 'Redis stores for Ruby frameworks'
+  s.description = 'Namespaced Rack::Session, Rack::Cache, I18n and cache Redis stores for Ruby web frameworks.'
 
   s.rubyforge_project = 'redis-store'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_paths = ["lib"]
+  s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
+  s.require_paths = ['lib']
   s.license       = 'MIT'
 
   s.add_dependency 'redis', '>= 2.2'
@@ -27,5 +27,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest', '~> 5'
   s.add_development_dependency 'git',      '~> 1.2'
   s.add_development_dependency 'redis-store-testing'
+  s.add_development_dependency 'rubocop'
 end
-

--- a/test/redis/distributed_store_test.rb
+++ b/test/redis/distributed_store_test.rb
@@ -1,28 +1,28 @@
 require 'test_helper'
 
-describe "Redis::DistributedStore" do
+describe 'Redis::DistributedStore' do
   def setup
     @dmr = Redis::DistributedStore.new [
-      {:host => "localhost", :port => "6380", :db => 0},
-      {:host => "localhost", :port => "6381", :db => 0}
+      { host: 'localhost', port: '6380', db: 0 },
+      { host: 'localhost', port: '6381', db: 0 }
     ]
-    @rabbit = OpenStruct.new :name => "bunny"
-    @white_rabbit = OpenStruct.new :color => "white"
-    @dmr.set "rabbit", @rabbit
+    @rabbit = OpenStruct.new name: 'bunny'
+    @white_rabbit = OpenStruct.new color: 'white'
+    @dmr.set 'rabbit', @rabbit
   end
 
   def teardown
-    @dmr.ring.nodes.each { |server| server.flushdb }
+    @dmr.ring.nodes.each(&:flushdb)
   end
 
-  it "accepts connection params" do
-    dmr = Redis::DistributedStore.new [ :host => "localhost", :port => "6380", :db => "1" ]
-    dmr.ring.nodes.size == 1
+  it 'accepts connection params' do
+    dmr = Redis::DistributedStore.new [host: 'localhost', port: '6380', db: '1']
+    dmr.ring.nodes.size.must_equal 1
     mr = dmr.ring.nodes.first
-    mr.to_s.must_equal("Redis Client connected to localhost:6380 against DB 1")
+    mr.to_s.must_equal('Redis Client connected to localhost:6380 against DB 1')
   end
 
-  it "forces reconnection" do
+  it 'forces reconnection' do
     @dmr.nodes.each do |node|
       node.expects(:reconnect)
     end
@@ -30,13 +30,13 @@ describe "Redis::DistributedStore" do
     @dmr.reconnect
   end
 
-  it "sets an object" do
-    @dmr.set "rabbit", @white_rabbit
-    @dmr.get("rabbit").must_equal(@white_rabbit)
+  it 'sets an object' do
+    @dmr.set 'rabbit', @white_rabbit
+    @dmr.get('rabbit').must_equal(@white_rabbit)
   end
 
-  it "gets an object" do
-    @dmr.get("rabbit").must_equal(@rabbit)
+  it 'gets an object' do
+    @dmr.get('rabbit').must_equal(@rabbit)
   end
 
   describe '#redis_version' do
@@ -53,15 +53,15 @@ describe "Redis::DistributedStore" do
     end
   end
 
-  describe "namespace" do
-    it "uses namespaced key" do
+  describe 'namespace' do
+    it 'uses namespaced key' do
       @dmr = Redis::DistributedStore.new [
-        {:host => "localhost", :port => "6380", :db => 0},
-        {:host => "localhost", :port => "6381", :db => 0}
-      ], :namespace => "theplaylist"
+        { host: 'localhost', port: '6380', db: 0 },
+        { host: 'localhost', port: '6381', db: 0 }
+      ], namespace: 'theplaylist'
 
-      @dmr.expects(:node_for).with("theplaylist:rabbit").returns(@dmr.nodes.first)
-      @dmr.get "rabbit"
+      @dmr.expects(:node_for).with('theplaylist:rabbit').returns(@dmr.nodes.first)
+      @dmr.get 'rabbit'
     end
   end
 end

--- a/test/redis/store/factory_test.rb
+++ b/test/redis/store/factory_test.rb
@@ -1,145 +1,145 @@
 require 'test_helper'
 
-describe "Redis::Store::Factory" do
-  describe ".create" do
-    describe "when not given any arguments" do
-      it "instantiates Redis::Store" do
+describe 'Redis::Store::Factory' do
+  describe '.create' do
+    describe 'when not given any arguments' do
+      it 'instantiates Redis::Store' do
         store = Redis::Store::Factory.create
         store.must_be_kind_of(Redis::Store)
-        store.to_s.must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0")
+        store.to_s.must_equal('Redis Client connected to 127.0.0.1:6379 against DB 0')
       end
     end
 
-    describe "when given a Hash" do
-      it "uses specified host" do
-        store = Redis::Store::Factory.create :host => "localhost"
-        store.to_s.must_equal("Redis Client connected to localhost:6379 against DB 0")
+    describe 'when given a Hash' do
+      it 'uses specified host' do
+        store = Redis::Store::Factory.create host: 'localhost'
+        store.to_s.must_equal('Redis Client connected to localhost:6379 against DB 0')
       end
 
-      it "uses specified port" do
-        store = Redis::Store::Factory.create :host => "localhost", :port => 6380
-        store.to_s.must_equal("Redis Client connected to localhost:6380 against DB 0")
+      it 'uses specified port' do
+        store = Redis::Store::Factory.create host: 'localhost', port: 6380
+        store.to_s.must_equal('Redis Client connected to localhost:6380 against DB 0')
       end
 
-      it "uses specified db" do
-        store = Redis::Store::Factory.create :host => "localhost", :port => 6380, :db => 13
-        store.to_s.must_equal("Redis Client connected to localhost:6380 against DB 13")
+      it 'uses specified db' do
+        store = Redis::Store::Factory.create host: 'localhost', port: 6380, db: 13
+        store.to_s.must_equal('Redis Client connected to localhost:6380 against DB 13')
       end
 
-      it "uses specified namespace" do
-        store = Redis::Store::Factory.create :namespace => "theplaylist"
-        store.to_s.must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist")
+      it 'uses specified namespace' do
+        store = Redis::Store::Factory.create namespace: 'theplaylist'
+        store.to_s.must_equal('Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist')
       end
 
-      it "uses specified key_prefix as namespace" do
-        store = Redis::Store::Factory.create :key_prefix => "theplaylist"
-        store.to_s.must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist")
+      it 'uses specified key_prefix as namespace' do
+        store = Redis::Store::Factory.create key_prefix: 'theplaylist'
+        store.to_s.must_equal('Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist')
       end
 
-      it "uses specified password" do
-        store = Redis::Store::Factory.create :password => "secret"
-        store.instance_variable_get(:@client).password.must_equal("secret")
+      it 'uses specified password' do
+        store = Redis::Store::Factory.create password: 'secret'
+        store.instance_variable_get(:@client).password.must_equal('secret')
       end
 
-      it "allows/disable marshalling" do
-        store = Redis::Store::Factory.create :marshalling => false
+      it 'allows/disable marshalling' do
+        store = Redis::Store::Factory.create marshalling: false
         store.instance_variable_get(:@marshalling).must_equal(false)
         store.instance_variable_get(:@options)[:raw].must_equal(true)
       end
 
-      it "should instantiate a Redis::DistributedStore store" do
+      it 'should instantiate a Redis::DistributedStore store' do
         store = Redis::Store::Factory.create(
-          {:host => "localhost", :port => 6379},
-          {:host => "localhost", :port => 6380}
+          { host: 'localhost', port: 6379 },
+          host: 'localhost', port: 6380
         )
         store.must_be_kind_of(Redis::DistributedStore)
-        store.nodes.map {|node| node.to_s }.must_equal([
-          "Redis Client connected to localhost:6379 against DB 0",
-          "Redis Client connected to localhost:6380 against DB 0",
-        ])
+        store.nodes.map(&:to_s).must_equal([
+                                             'Redis Client connected to localhost:6379 against DB 0',
+                                             'Redis Client connected to localhost:6380 against DB 0'
+                                           ])
       end
     end
 
-    describe "when given a String" do
-      it "uses specified host" do
-        store = Redis::Store::Factory.create "redis://127.0.0.1"
-        store.to_s.must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0")
+    describe 'when given a String' do
+      it 'uses specified host' do
+        store = Redis::Store::Factory.create 'redis://127.0.0.1'
+        store.to_s.must_equal('Redis Client connected to 127.0.0.1:6379 against DB 0')
       end
 
-      it "uses specified port" do
-        store = Redis::Store::Factory.create "redis://127.0.0.1:6380"
-        store.to_s.must_equal("Redis Client connected to 127.0.0.1:6380 against DB 0")
+      it 'uses specified port' do
+        store = Redis::Store::Factory.create 'redis://127.0.0.1:6380'
+        store.to_s.must_equal('Redis Client connected to 127.0.0.1:6380 against DB 0')
       end
 
-      it "uses specified db" do
-        store = Redis::Store::Factory.create "redis://127.0.0.1:6380/13"
-        store.to_s.must_equal("Redis Client connected to 127.0.0.1:6380 against DB 13")
+      it 'uses specified db' do
+        store = Redis::Store::Factory.create 'redis://127.0.0.1:6380/13'
+        store.to_s.must_equal('Redis Client connected to 127.0.0.1:6380 against DB 13')
       end
 
-      it "uses specified namespace" do
-        store = Redis::Store::Factory.create "redis://127.0.0.1:6379/0/theplaylist"
-        store.to_s.must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist")
+      it 'uses specified namespace' do
+        store = Redis::Store::Factory.create 'redis://127.0.0.1:6379/0/theplaylist'
+        store.to_s.must_equal('Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist')
       end
 
-      it "uses specified password" do
-        store = Redis::Store::Factory.create "redis://:secret@127.0.0.1:6379/0/theplaylist"
-        store.instance_variable_get(:@client).password.must_equal("secret")
+      it 'uses specified password' do
+        store = Redis::Store::Factory.create 'redis://:secret@127.0.0.1:6379/0/theplaylist'
+        store.instance_variable_get(:@client).password.must_equal('secret')
       end
 
-      it "correctly uses specified ipv6 host" do
-        store = Redis::Store::Factory.create "redis://[::1]:6380"
-        store.to_s.must_equal("Redis Client connected to [::1]:6380 against DB 0")
-        store.client.host.must_equal("::1")
+      it 'correctly uses specified ipv6 host' do
+        store = Redis::Store::Factory.create 'redis://[::1]:6380'
+        store.to_s.must_equal('Redis Client connected to [::1]:6380 against DB 0')
+        store.client.host.must_equal('::1')
       end
 
-      it "instantiates Redis::DistributedStore" do
-        store = Redis::Store::Factory.create "redis://127.0.0.1:6379", "redis://127.0.0.1:6380"
+      it 'instantiates Redis::DistributedStore' do
+        store = Redis::Store::Factory.create 'redis://127.0.0.1:6379', 'redis://127.0.0.1:6380'
         store.must_be_kind_of(Redis::DistributedStore)
-        store.nodes.map {|node| node.to_s }.must_equal([
-          "Redis Client connected to 127.0.0.1:6379 against DB 0",
-          "Redis Client connected to 127.0.0.1:6380 against DB 0",
-        ])
+        store.nodes.map(&:to_s).must_equal([
+                                             'Redis Client connected to 127.0.0.1:6379 against DB 0',
+                                             'Redis Client connected to 127.0.0.1:6380 against DB 0'
+                                           ])
       end
     end
 
-    describe 'when given host Hash and options Hash' do 
+    describe 'when given host Hash and options Hash' do
       it 'instantiates Redis::Store and merges options' do
-        store = Redis::Store::Factory.create(
-          { :host => '127.0.0.1', :port => '6379' }, 
-          { :namespace => 'theplaylist' }
+        Redis::Store::Factory.create(
+          { host: '127.0.0.1', port: '6379' },
+          namespace: 'theplaylist'
         )
       end
 
-      it 'instantiates Redis::DistributedStore and merges options' do 
+      it 'instantiates Redis::DistributedStore and merges options' do
         store = Redis::Store::Factory.create(
-          { :host => '127.0.0.1', :port => '6379' }, 
-          { :host => '127.0.0.1', :port => '6380' }, 
-          { :namespace => 'theplaylist' }
+          { host: '127.0.0.1', port: '6379' },
+          { host: '127.0.0.1', port: '6380' },
+          namespace: 'theplaylist'
         )
-        store.nodes.map {|node| node.to_s }.must_equal([
-          "Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist",
-          "Redis Client connected to 127.0.0.1:6380 against DB 0 with namespace theplaylist"
-        ])
+        store.nodes.map(&:to_s).must_equal([
+                                             'Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist',
+                                             'Redis Client connected to 127.0.0.1:6380 against DB 0 with namespace theplaylist'
+                                           ])
       end
     end
 
-    describe 'when given host String and options Hash' do 
-      it 'instantiates Redis::Store and merges options' do 
-        store = Redis::Store::Factory.create "redis://127.0.0.1", { :namespace => 'theplaylist' }
-        store.to_s.must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist")
+    describe 'when given host String and options Hash' do
+      it 'instantiates Redis::Store and merges options' do
+        store = Redis::Store::Factory.create 'redis://127.0.0.1', namespace: 'theplaylist'
+        store.to_s.must_equal('Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist')
       end
 
-      it 'instantiates Redis::DistributedStore and merges options' do 
-        store = Redis::Store::Factory.create "redis://127.0.0.1:6379", "redis://127.0.0.1:6380", { :namespace => 'theplaylist' }
-        store.nodes.map {|node| node.to_s }.must_equal([
-          "Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist",
-          "Redis Client connected to 127.0.0.1:6380 against DB 0 with namespace theplaylist",
-        ])
+      it 'instantiates Redis::DistributedStore and merges options' do
+        store = Redis::Store::Factory.create 'redis://127.0.0.1:6379', 'redis://127.0.0.1:6380', namespace: 'theplaylist'
+        store.nodes.map(&:to_s).must_equal([
+                                             'Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist',
+                                             'Redis Client connected to 127.0.0.1:6380 against DB 0 with namespace theplaylist'
+                                           ])
       end
 
       it 'instantiates Redis::Store and sets namespace from String' do
-        store = Redis::Store::Factory.create "redis://127.0.0.1:6379/0/theplaylist", { :expire_after => 5 }
-        store.to_s.must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist")
+        store = Redis::Store::Factory.create 'redis://127.0.0.1:6379/0/theplaylist', expire_after: 5
+        store.to_s.must_equal('Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist')
       end
     end
   end

--- a/test/redis/store/interface_test.rb
+++ b/test/redis/store/interface_test.rb
@@ -9,19 +9,19 @@ describe Redis::Store::Interface do
     @r = InterfacedRedis.new
   end
 
-  it "should get an element" do
-    lambda { @r.get("key", :option => true) } #.wont_raise ArgumentError
+  it 'should get an element' do
+    -> { @r.get('key', option: true) } # .wont_raise ArgumentError
   end
 
-  it "should set an element" do
-    lambda { @r.set("key", "value", :option => true) } #.wont_raise ArgumentError
+  it 'should set an element' do
+    -> { @r.set('key', 'value', option: true) } # .wont_raise ArgumentError
   end
 
-  it "should setnx an element" do
-    lambda { @r.setnx("key", "value", :option => true) } #.wont_raise ArgumentError
+  it 'should setnx an element' do
+    -> { @r.setnx('key', 'value', option: true) } # .wont_raise ArgumentError
   end
 
-  it "should setex an element" do
-    lambda { @r.setex("key", 1, "value", :option => true) } #.wont_raise ArgumentError
+  it 'should setex an element' do
+    -> { @r.setex('key', 1, 'value', option: true) } # .wont_raise ArgumentError
   end
 end

--- a/test/redis/store/marshalling_test.rb
+++ b/test/redis/store/marshalling_test.rb
@@ -1,12 +1,12 @@
 require 'test_helper'
 
-describe "Redis::Marshalling" do
+describe 'Redis::Marshalling' do
   def setup
-    @store = Redis::Store.new :marshalling => true
-    @rabbit = OpenStruct.new :name => "bunny"
-    @white_rabbit = OpenStruct.new :color => "white"
-    @store.set "rabbit", @rabbit
-    @store.del "rabbit2"
+    @store = Redis::Store.new marshalling: true
+    @rabbit = OpenStruct.new name: 'bunny'
+    @white_rabbit = OpenStruct.new color: 'white'
+    @store.set 'rabbit', @rabbit
+    @store.del 'rabbit2'
   end
 
   def teardown
@@ -14,147 +14,147 @@ describe "Redis::Marshalling" do
     @store.quit
   end
 
-  it "unmarshals on get" do
-    @store.get("rabbit").must_equal(@rabbit)
+  it 'unmarshals on get' do
+    @store.get('rabbit').must_equal(@rabbit)
   end
 
-  it "marshals on set" do
-    @store.set "rabbit", @white_rabbit
-    @store.get("rabbit").must_equal(@white_rabbit)
+  it 'marshals on set' do
+    @store.set 'rabbit', @white_rabbit
+    @store.get('rabbit').must_equal(@white_rabbit)
   end
 
-  it "marshals on multi set" do
-    @store.mset("rabbit", @white_rabbit, "rabbit2", @rabbit)
-    @store.get("rabbit").must_equal(@white_rabbit)
-    @store.get("rabbit2").must_equal(@rabbit)
+  it 'marshals on multi set' do
+    @store.mset('rabbit', @white_rabbit, 'rabbit2', @rabbit)
+    @store.get('rabbit').must_equal(@white_rabbit)
+    @store.get('rabbit2').must_equal(@rabbit)
   end
 
-  if RUBY_VERSION.match /1\.9/
+  if RUBY_VERSION =~ /1\.9/
     it "doesn't unmarshal on get if raw option is true" do
-      @store.get("rabbit", :raw => true).must_equal("\x04\bU:\x0FOpenStruct{\x06:\tnameI\"\nbunny\x06:\x06EF")
+      @store.get('rabbit', raw: true).must_equal("\x04\bU:\x0FOpenStruct{\x06:\tnameI\"\nbunny\x06:\x06EF")
     end
   else
     it "doesn't unmarshal on get if raw option is true" do
-      @store.get("rabbit", :raw => true).must_include("\x04\bU:\x0FOpenStruct{\x06:\tname")
+      @store.get('rabbit', raw: true).must_include("\x04\bU:\x0FOpenStruct{\x06:\tname")
     end
   end
 
   it "doesn't marshal set if raw option is true" do
-    @store.set "rabbit", @white_rabbit, :raw => true
-    @store.get("rabbit", :raw => true).must_equal(%(#<OpenStruct color="white">))
+    @store.set 'rabbit', @white_rabbit, raw: true
+    @store.get('rabbit', raw: true).must_equal(%(#<OpenStruct color="white">))
   end
 
   it "doesn't marshal multi set if raw option is true" do
-    @store.mset("rabbit", @white_rabbit, "rabbit2", @rabbit, :raw => true)
-    @store.get("rabbit", :raw => true).must_equal(%(#<OpenStruct color="white">))
-    @store.get("rabbit2", :raw => true).must_equal(%(#<OpenStruct name="bunny">))
+    @store.mset('rabbit', @white_rabbit, 'rabbit2', @rabbit, raw: true)
+    @store.get('rabbit', raw: true).must_equal(%(#<OpenStruct color="white">))
+    @store.get('rabbit2', raw: true).must_equal(%(#<OpenStruct name="bunny">))
   end
 
   it "doesn't unmarshal if get returns an empty string" do
-    @store.set "empty_string", ""
-    @store.get("empty_string").must_equal("")
-    # TODO use a meaningful Exception
+    @store.set 'empty_string', ''
+    @store.get('empty_string').must_equal('')
+    # TODO: use a meaningful Exception
     # lambda { @store.get("empty_string").must_equal("") }.wont_raise Exception
   end
 
   it "doesn't set an object if already exist" do
-    @store.setnx "rabbit", @white_rabbit
-    @store.get("rabbit").must_equal(@rabbit)
+    @store.setnx 'rabbit', @white_rabbit
+    @store.get('rabbit').must_equal(@rabbit)
   end
 
-  it "marshals on set unless exists" do
-    @store.setnx "rabbit2", @white_rabbit
-    @store.get("rabbit2").must_equal(@white_rabbit)
+  it 'marshals on set unless exists' do
+    @store.setnx 'rabbit2', @white_rabbit
+    @store.get('rabbit2').must_equal(@white_rabbit)
   end
 
   it "doesn't marshal on set unless exists if raw option is true" do
-    @store.setnx "rabbit2", @white_rabbit, :raw => true
-    @store.get("rabbit2", :raw => true).must_equal(%(#<OpenStruct color="white">))
+    @store.setnx 'rabbit2', @white_rabbit, raw: true
+    @store.get('rabbit2', raw: true).must_equal(%(#<OpenStruct color="white">))
   end
 
-  it "marshals on set expire" do
-    @store.setex "rabbit2", 1, @white_rabbit
-    @store.get("rabbit2").must_equal(@white_rabbit)
+  it 'marshals on set expire' do
+    @store.setex 'rabbit2', 1, @white_rabbit
+    @store.get('rabbit2').must_equal(@white_rabbit)
     sleep 2
-    @store.get("rabbit2").must_be_nil
+    @store.get('rabbit2').must_be_nil
   end
 
-  it "marshals setex (over a distributed store)" do
+  it 'marshals setex (over a distributed store)' do
     @store = Redis::DistributedStore.new [
-      {:host => "localhost", :port => "6380", :db => 0},
-      {:host => "localhost", :port => "6381", :db => 0}
+      { host: 'localhost', port: '6380', db: 0 },
+      { host: 'localhost', port: '6381', db: 0 }
     ]
-    @store.setex "rabbit", 50, @white_rabbit
-    @store.get("rabbit").must_equal(@white_rabbit)
+    @store.setex 'rabbit', 50, @white_rabbit
+    @store.get('rabbit').must_equal(@white_rabbit)
   end
 
   it "doesn't marshal setex if raw option is true (over a distributed store)" do
     @store = Redis::DistributedStore.new [
-      {:host => "localhost", :port => "6380", :db => 0},
-      {:host => "localhost", :port => "6381", :db => 0}
+      { host: 'localhost', port: '6380', db: 0 },
+      { host: 'localhost', port: '6381', db: 0 }
     ]
-    @store.setex "rabbit", 50, @white_rabbit, :raw => true
-    @store.get("rabbit", :raw => true).must_equal(%(#<OpenStruct color="white">))
+    @store.setex 'rabbit', 50, @white_rabbit, raw: true
+    @store.get('rabbit', raw: true).must_equal(%(#<OpenStruct color="white">))
   end
 
   it "doesn't unmarshal on multi get" do
-    @store.set "rabbit2", @white_rabbit
-    rabbits = @store.mget "rabbit", "rabbit2"
+    @store.set 'rabbit2', @white_rabbit
+    rabbits = @store.mget 'rabbit', 'rabbit2'
     rabbit, rabbit2 = rabbits
     rabbits.length.must_equal(2)
     rabbit.must_equal(@rabbit)
     rabbit2.must_equal(@white_rabbit)
   end
 
-  if RUBY_VERSION.match /1\.9/
+  if RUBY_VERSION =~ /1\.9/
     it "doesn't unmarshal on multi get if raw option is true" do
-      @store.set "rabbit2", @white_rabbit
-      rabbit, rabbit2 = @store.mget "rabbit", "rabbit2", :raw => true
+      @store.set 'rabbit2', @white_rabbit
+      rabbit, rabbit2 = @store.mget 'rabbit', 'rabbit2', raw: true
       rabbit.must_equal("\x04\bU:\x0FOpenStruct{\x06:\tnameI\"\nbunny\x06:\x06EF")
       rabbit2.must_equal("\x04\bU:\x0FOpenStruct{\x06:\ncolorI\"\nwhite\x06:\x06EF")
     end
   else
     it "doesn't unmarshal on multi get if raw option is true" do
-      @store.set "rabbit2", @white_rabbit
-      rabbit, rabbit2 = @store.mget "rabbit", "rabbit2", :raw => true
+      @store.set 'rabbit2', @white_rabbit
+      rabbit, rabbit2 = @store.mget 'rabbit', 'rabbit2', raw: true
       rabbit.must_include("\x04\bU:\x0FOpenStruct{\x06:\tname")
       rabbit2.must_include("\x04\bU:\x0FOpenStruct{\x06:\ncolor")
     end
   end
 
-  describe "binary safety" do
-    it "marshals objects" do
-      utf8_key = [51339].pack("U*")
-      ascii_rabbit = OpenStruct.new(:name => [128].pack("C*"))
+  describe 'binary safety' do
+    it 'marshals objects' do
+      utf8_key = [51_339].pack('U*')
+      ascii_rabbit = OpenStruct.new(name: [128].pack('C*'))
 
       @store.set(utf8_key, ascii_rabbit)
       @store.get(utf8_key).must_equal(ascii_rabbit)
     end
 
-    it "gets and sets raw values" do
-      utf8_key = [51339].pack("U*")
-      ascii_string = [128].pack("C*")
+    it 'gets and sets raw values' do
+      utf8_key = [51_339].pack('U*')
+      ascii_string = [128].pack('C*')
 
-      @store.set(utf8_key, ascii_string, :raw => true)
-      @store.get(utf8_key, :raw => true).bytes.to_a.must_equal(ascii_string.bytes.to_a)
+      @store.set(utf8_key, ascii_string, raw: true)
+      @store.get(utf8_key, raw: true).bytes.to_a.must_equal(ascii_string.bytes.to_a)
     end
 
-    it "marshals objects on setnx" do
-      utf8_key = [51339].pack("U*")
-      ascii_rabbit = OpenStruct.new(:name => [128].pack("C*"))
+    it 'marshals objects on setnx' do
+      utf8_key = [51_339].pack('U*')
+      ascii_rabbit = OpenStruct.new(name: [128].pack('C*'))
 
       @store.del(utf8_key)
       @store.setnx(utf8_key, ascii_rabbit)
       @store.get(utf8_key).must_equal(ascii_rabbit)
     end
 
-    it "gets and sets raw values on setnx" do
-      utf8_key = [51339].pack("U*")
-      ascii_string = [128].pack("C*")
+    it 'gets and sets raw values on setnx' do
+      utf8_key = [51_339].pack('U*')
+      ascii_string = [128].pack('C*')
 
       @store.del(utf8_key)
-      @store.setnx(utf8_key, ascii_string, :raw => true)
-      @store.get(utf8_key, :raw => true).bytes.to_a.must_equal(ascii_string.bytes.to_a)
+      @store.setnx(utf8_key, ascii_string, raw: true)
+      @store.get(utf8_key, raw: true).bytes.to_a.must_equal(ascii_string.bytes.to_a)
     end
   end if defined?(Encoding)
 end

--- a/test/redis/store/namespace_test.rb
+++ b/test/redis/store/namespace_test.rb
@@ -1,14 +1,14 @@
 require 'test_helper'
 
-describe "Redis::Store::Namespace" do
+describe 'Redis::Store::Namespace' do
   def setup
-    @namespace = "theplaylist"
-    @store  = Redis::Store.new :namespace => @namespace, :marshalling => false # TODO remove mashalling option
+    @namespace = 'theplaylist'
+    @store  = Redis::Store.new namespace: @namespace, marshalling: false # TODO: remove mashalling option
     @client = @store.instance_variable_get(:@client)
-    @rabbit = "bunny"
+    @rabbit = 'bunny'
     @default_store = Redis::Store.new
     @other_namespace = 'other'
-    @other_store = Redis::Store.new :namespace => @other_namespace
+    @other_store = Redis::Store.new namespace: @other_namespace
   end
 
   def teardown
@@ -22,18 +22,18 @@ describe "Redis::Store::Namespace" do
     @other_store.quit
   end
 
-  it "only decorates instances that need to be namespaced" do
+  it 'only decorates instances that need to be namespaced' do
     store  = Redis::Store.new
     client = store.instance_variable_get(:@client)
-    client.expects(:call).with([:get, "rabbit"])
-    store.get("rabbit")
+    client.expects(:call).with([:get, 'rabbit'])
+    store.get('rabbit')
   end
 
   it "doesn't namespace a key which is already namespaced" do
     @store.send(:interpolate, "#{@namespace}:rabbit").must_equal("#{@namespace}:rabbit")
   end
 
-  it "should only delete namespaced keys" do
+  it 'should only delete namespaced keys' do
     @default_store.set 'abc', 'cba'
     @store.set 'def', 'fed'
 
@@ -54,30 +54,30 @@ describe "Redis::Store::Namespace" do
     end
   end
 
-  it "should not try to delete missing namespaced keys" do
-    empty_store = Redis::Store.new :namespace => 'empty'
+  it 'should not try to delete missing namespaced keys' do
+    empty_store = Redis::Store.new namespace: 'empty'
     empty_store.flushdb
     empty_store.keys.must_be_empty
   end
 
-  it "should work with dynamic namespace" do
-    $ns = "ns1"
-    dyn_store = Redis::Store.new :namespace => -> { $ns }
+  it 'should work with dynamic namespace' do
+    $ns = 'ns1'
+    dyn_store = Redis::Store.new namespace: -> { $ns }
     dyn_store.set 'key', 'x'
-    $ns = "ns2"
+    $ns = 'ns2'
     dyn_store.set 'key', 'y'
-    $ns = "ns3"
+    $ns = 'ns3'
     dyn_store.set 'key', 'z'
     dyn_store.flushdb
     r3 = dyn_store.get 'key'
-    $ns = "ns2"
+    $ns = 'ns2'
     r2 = dyn_store.get 'key'
-    $ns = "ns1"
+    $ns = 'ns1'
     r1 = dyn_store.get 'key'
     r1.must_equal('x') && r2.must_equal('y') && r3.must_equal(nil)
   end
 
-  it "namespaces setex and ttl" do
+  it 'namespaces setex and ttl' do
     @store.flushdb
     @other_store.flushdb
 
@@ -90,67 +90,67 @@ describe "Redis::Store::Namespace" do
   end
 
   describe 'method calls' do
-    let(:store){Redis::Store.new :namespace => @namespace, :marshalling => false}
-    let(:client){store.instance_variable_get(:@client)}
+    let(:store) { Redis::Store.new namespace: @namespace, marshalling: false }
+    let(:client) { store.instance_variable_get(:@client) }
 
-    it "should namespace get" do
-       client.expects(:call).with([:get, "#{@namespace}:rabbit"]).once
-       store.get("rabbit")
+    it 'should namespace get' do
+      client.expects(:call).with([:get, "#{@namespace}:rabbit"]).once
+      store.get('rabbit')
     end
 
-    it "should namespace set" do
-       client.expects(:call).with([:set, "#{@namespace}:rabbit", @rabbit])
-       store.set "rabbit", @rabbit
+    it 'should namespace set' do
+      client.expects(:call).with([:set, "#{@namespace}:rabbit", @rabbit])
+      store.set 'rabbit', @rabbit
     end
 
-    it "should namespace setnx" do
-       client.expects(:call).with([:setnx, "#{@namespace}:rabbit", @rabbit])
-       store.setnx "rabbit", @rabbit
+    it 'should namespace setnx' do
+      client.expects(:call).with([:setnx, "#{@namespace}:rabbit", @rabbit])
+      store.setnx 'rabbit', @rabbit
     end
 
-    it "should namespace del with single key" do
-       client.expects(:call).with([:del, "#{@namespace}:rabbit"])
-       store.del "rabbit"
+    it 'should namespace del with single key' do
+      client.expects(:call).with([:del, "#{@namespace}:rabbit"])
+      store.del 'rabbit'
     end
 
-    it "should namespace del with multiple keys" do
-       client.expects(:call).with([:del, "#{@namespace}:rabbit", "#{@namespace}:white_rabbit"])
-       store.del "rabbit", "white_rabbit"
+    it 'should namespace del with multiple keys' do
+      client.expects(:call).with([:del, "#{@namespace}:rabbit", "#{@namespace}:white_rabbit"])
+      store.del 'rabbit', 'white_rabbit'
     end
 
-    it "should namespace keys" do
-       store.set "rabbit", @rabbit
-       store.keys("rabb*").must_equal [ "rabbit" ]
+    it 'should namespace keys' do
+      store.set 'rabbit', @rabbit
+      store.keys('rabb*').must_equal ['rabbit']
     end
 
-    it "should namespace exists" do
-       client.expects(:call).with([:exists, "#{@namespace}:rabbit"])
-       store.exists "rabbit"
+    it 'should namespace exists' do
+      client.expects(:call).with([:exists, "#{@namespace}:rabbit"])
+      store.exists 'rabbit'
     end
 
-    it "should namespace incrby" do
-       client.expects(:call).with([:incrby, "#{@namespace}:counter", 1])
-       store.incrby "counter", 1
+    it 'should namespace incrby' do
+      client.expects(:call).with([:incrby, "#{@namespace}:counter", 1])
+      store.incrby 'counter', 1
     end
 
-    it "should namespace decrby" do
-       client.expects(:call).with([:decrby, "#{@namespace}:counter", 1])
-       store.decrby "counter", 1
+    it 'should namespace decrby' do
+      client.expects(:call).with([:decrby, "#{@namespace}:counter", 1])
+      store.decrby 'counter', 1
     end
 
-    it "should namespace mget" do
-       client.expects(:call).with([:mget, "#{@namespace}:rabbit", "#{@namespace}:white_rabbit"])
-       store.mget "rabbit", "white_rabbit"
+    it 'should namespace mget' do
+      client.expects(:call).with([:mget, "#{@namespace}:rabbit", "#{@namespace}:white_rabbit"])
+      store.mget 'rabbit', 'white_rabbit'
     end
 
-    it "should namespace expire" do
-       client.expects(:call).with([:expire, "#{@namespace}:rabbit", 60]).once
-       store.expire("rabbit",60)
+    it 'should namespace expire' do
+      client.expects(:call).with([:expire, "#{@namespace}:rabbit", 60]).once
+      store.expire('rabbit', 60)
     end
 
-    it "should namespace ttl" do
-       client.expects(:call).with([:ttl, "#{@namespace}:rabbit"]).once
-       store.ttl("rabbit")
+    it 'should namespace ttl' do
+      client.expects(:call).with([:ttl, "#{@namespace}:rabbit"]).once
+      store.ttl('rabbit')
     end
   end
 end

--- a/test/redis/store/redis_version_test.rb
+++ b/test/redis/store/redis_version_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
-describe "Redis::RedisVersion" do
+describe 'Redis::RedisVersion' do
   def setup
-    @store  = Redis::Store.new
+    @store = Redis::Store.new
   end
 
   def teardown
@@ -26,4 +26,3 @@ describe "Redis::RedisVersion" do
     end
   end
 end
-

--- a/test/redis/store/ttl_test.rb
+++ b/test/redis/store/ttl_test.rb
@@ -32,13 +32,13 @@ class MockRedis
     @setnxes.include?(a)
   end
 
-  def multi(&block)
+  def multi
     instance_eval do
       def setnx(*a)
         @setnxes << a
       end
 
-      block.call
+      yield
     end
   end
 
@@ -49,7 +49,6 @@ class MockRedis
   def has_expire?(*a)
     @expires.include?(a)
   end
-
 end
 
 class MockTtlStore < MockRedis
@@ -59,7 +58,7 @@ end
 describe MockTtlStore do
   let(:key) { 'hello' }
   let(:mock_value) { 'value' }
-  let(:options) { { :expire_after => 3600 } }
+  let(:options) { { expire_after: 3600 } }
   let(:redis) { MockTtlStore.new }
 
   describe '#set' do
@@ -73,13 +72,13 @@ describe MockTtlStore do
     describe 'with options' do
       it 'must call setex with proper expiry and set raw to true' do
         redis.set(key, mock_value, options)
-        redis.has_setex?(key, options[:expire_after], mock_value, :raw => true).must_equal true
+        redis.has_setex?(key, options[:expire_after], mock_value, raw: true).must_equal true
       end
     end
 
     describe 'with nx and ex option' do
       it 'must call super with key and value and options' do
-        set_options = {nx: true, ex: 3600}
+        set_options = { nx: true, ex: 3600 }
         redis.set(key, mock_value, set_options)
         redis.has_set?(key, mock_value, set_options).must_equal true
       end
@@ -103,7 +102,7 @@ describe MockTtlStore do
     describe 'with expiry' do
       it 'must call setnx with key and value and set raw to true' do
         redis.setnx(key, mock_value, options)
-        redis.has_setnx?(key, mock_value, :raw => true).must_equal true
+        redis.has_setnx?(key, mock_value, raw: true).must_equal true
       end
 
       it 'must call expire' do

--- a/test/redis/store_test.rb
+++ b/test/redis/store_test.rb
@@ -11,18 +11,18 @@ describe Redis::Store do
     @store.quit
   end
 
-  it "returns useful informations about the server" do
+  it 'returns useful informations about the server' do
     @store.to_s.must_equal("Redis Client connected to #{@client.host}:#{@client.port} against DB #{@client.db}")
   end
 
-  it "must force reconnection" do
+  it 'must force reconnection' do
     @client.expects(:reconnect)
     @store.reconnect
   end
 
   describe '#set' do
     describe 'with expiry' do
-      let(:options) { { :expire_after => 3600 } }
+      let(:options) { { expire_after: 3600 } }
 
       it 'must not double marshall' do
         Marshal.expects(:dump).once
@@ -43,7 +43,7 @@ describe Redis::Store do
         @store.del(key)
         @store.set(key, mock_value, {}).must_equal 'OK'
         @store.set(key, mock_value, {}).must_equal 'OK'
-        @store.ttl(key).must_equal -1
+        @store.ttl(key).must_equal(-1)
 
         # with ex and nx options, the key can only be set once and a ttl will be set
         @store.del(key)
@@ -56,7 +56,7 @@ describe Redis::Store do
 
   describe '#setnx' do
     describe 'with expiry' do
-      let(:options) { { :expire_after => 3600 } }
+      let(:options) { { expire_after: 3600 } }
 
       it 'must not double marshall' do
         Marshal.expects(:dump).once

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,7 @@ require 'mocha/setup'
 require 'redis'
 require 'redis-store'
 
-$DEBUG = ENV["DEBUG"] === "true"
+$DEBUG = ENV['DEBUG'] == 'true'
 
 Redis::DistributedStore.send(:class_variable_set, :@@timeout, 30)
 
@@ -15,6 +15,6 @@ module Kernel
     $VERBOSE = nil
     result = yield
     $VERBOSE = original_verbosity
-    return result
+    result
   end
 end


### PR DESCRIPTION
This change imposes a style guide, that can be altered by updates to
`.rubocop.yml`, for use on this gem. Hopefully soon I'll be able to
access CodeClimate and set up automatic code style checks using the
provided RuboCop configuration. The purpose of adding a style guide to
this, and eventually all, redis-store repo(es) is to emphasize
readability, understandability, and to keep us up-to-date with the
latest "dialect" of Ruby that people are using. This helps new
developers as well as veterans get involved in our various projects.

Until we have some time to write documentation and solve some of the
other ignored RuboCop offenses, a few different style and lint checks
have been disabled so that we can continue working on the project and
not get bogged down by style errors that are not practical to fix at
this time.
