### PR TITLE
honor unless_exist for setnx_with_expire

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
   - 2.2
   - 2.3.0
   - ruby-head
-  - rbx-2
+  - rbx
   - jruby-19mode
   - jruby-head
 bundler_args: '--path vendor/bundle'

--- a/lib/redis/store/ttl.rb
+++ b/lib/redis/store/ttl.rb
@@ -11,17 +11,17 @@ class Redis
 
       def setnx(key, value, options = nil)
         if ttl = expires_in(options)
-          setnx_with_expire(key, value, ttl.to_i)
+          setnx_with_expire(key, value, ttl.to_i, options)
         else
           super(key, value)
         end
       end
 
       protected
-        def setnx_with_expire(key, value, ttl)
+        def setnx_with_expire(key, value, ttl, options = {})
           multi do
-            setnx(key, value, :raw => true)
-            expire(key, ttl)
+            was_set = setnx(key, value, :raw => true)
+            expire(key, ttl) unless options[:unless_exist] && !was_set
           end
         end
 

--- a/test/redis/store/ttl_test.rb
+++ b/test/redis/store/ttl_test.rb
@@ -110,6 +110,21 @@ describe MockTtlStore do
         redis.setnx(key, mock_value, options)
         redis.has_expire?(key, options[:expire_after]).must_equal true
       end
+
+      describe 'with :unless_exist option truthy' do
+        let(:options) { { :expire_after => 3600, :unless_exist => true } }
+
+        it 'must call expire for a successful setnx' do
+          redis.setnx(key, mock_value, options)
+          redis.has_expire?(key, options[:expire_after]).must_equal true
+        end
+
+        it 'must not call expire for an unsuccessful setnx' do
+          def redis.setnx(*a) false end
+          redis.setnx(key, mock_value, options)
+          redis.has_expire?(key, options[:expire_after]).must_equal false
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This commit prevents a preexisting key's `ttl` from being refreshed when `options[:unless_exist]` is specified. For most/many `Store` implementations, this is the expected behavior, as providing this option [returns `false` prior to reassigning the entry (and it's new `ttl`) back to the store.](https://git.io/vXMXS)

As an example, imagine the store is capturing `oauth_nonce` request parameters for validation and a well meaning developer uses a `RedisStore` implementation something like this:
```
def valid?(nonce)
  Rails.cache.write(nonce, true, { expires_in: 1.minute, unless_exist: true }).all?
end
```
As `RedisStore` is designed currently, a replay attack would not reassign the key (as it already exists in the store), but it *would* refresh the expiration time.