### PR TITLE
password unescape

### DIFF
--- a/lib/redis/store/factory.rb
+++ b/lib/redis/store/factory.rb
@@ -71,7 +71,7 @@ class Redis
         options = {
           :host     => uri.hostname,
           :port     => uri.port || DEFAULT_PORT, 
-          :password => uri.password
+          :password => CGI::unescape(uri.password)
         }
 
         options[:db]        = db.to_i   if db


### PR DESCRIPTION
when complex passwords are used, they need to be escaped to be used in the url, otherwise it fails parsing.