### PR TITLE
Support distributed mget / read_multi

### DIFF
--- a/lib/redis/store/namespace.rb
+++ b/lib/redis/store/namespace.rb
@@ -47,14 +47,14 @@ class Redis
         super(*keys.map {|key| interpolate(key) }) if keys.any?
       end
 
-      def mget(*keys)
+      def mget(*keys, &blk)
         options = (keys.pop if keys.last.is_a? Hash) || {}
         if keys.any?
           # Serialization gets extended before Namespace does, so we need to pass options further
           if singleton_class.ancestors.include? Serialization
-            super(*keys.map {|key| interpolate(key) }, options)
+            super(*keys.map {|key| interpolate(key) }, options, &blk)
           else
-            super(*keys.map {|key| interpolate(key) })
+            super(*keys.map {|key| interpolate(key) }, &blk)
           end
         end
       end

--- a/lib/redis/store/serialization.rb
+++ b/lib/redis/store/serialization.rb
@@ -17,10 +17,11 @@ class Redis
         _unmarshal super(key), options
       end
 
-      def mget(*keys)
+      def mget(*keys, &blk)
         options = keys.pop if keys.last.is_a?(Hash)
-        super(*keys).map do |result|
-          _unmarshal result, options
+        super(*keys) do |reply|
+          reply.map! { |value| _unmarshal value, options }
+          blk ? blk.call(reply) : reply
         end
       end
 

--- a/test/redis/distributed_store_test.rb
+++ b/test/redis/distributed_store_test.rb
@@ -39,6 +39,32 @@ describe "Redis::DistributedStore" do
     @dmr.get("rabbit").must_equal(@rabbit)
   end
 
+  it "mget" do
+    @dmr.set "rabbit2", @white_rabbit
+    begin
+      @dmr.mget "rabbit", "rabbit2" do |rabbits|
+        rabbit, rabbit2 = rabbits
+        rabbits.length.must_equal(2)
+        rabbit.must_equal(@rabbit)
+        rabbit2.must_equal(@white_rabbit)
+      end
+    rescue Redis::Distributed::CannotDistribute
+      # Not supported on redis-rb < 4, and hence Ruby < 2.2.
+    end
+  end
+
+  it "mapped_mget" do
+    @dmr.set "rabbit2", @white_rabbit
+    begin
+      result = @dmr.mapped_mget("rabbit", "rabbit2")
+      result.keys.must_equal %w[ rabbit rabbit2 ]
+      result["rabbit"].must_equal @rabbit
+      result["rabbit2"].must_equal @white_rabbit
+    rescue Redis::Distributed::CannotDistribute
+      # Not supported on redis-rb < 4, and hence Ruby < 2.2.
+    end
+  end
+
   describe '#redis_version' do
     it 'returns redis version' do
       @dmr.nodes.first.expects(:redis_version)

--- a/test/redis/store/namespace_test.rb
+++ b/test/redis/store/namespace_test.rb
@@ -139,8 +139,18 @@ describe "Redis::Store::Namespace" do
     end
 
     it "should namespace mget" do
-       client.expects(:call).with([:mget, "#{@namespace}:rabbit", "#{@namespace}:white_rabbit"])
-       store.mget "rabbit", "white_rabbit"
+      client.expects(:call).with([:mget, "#{@namespace}:rabbit", "#{@namespace}:white_rabbit"]).returns(%w[ foo bar ])
+      store.mget "rabbit", "white_rabbit" do |result|
+        result.must_equal(%w[ foo bar ])
+      end
+    end
+
+    it "should namespace mapped_mget" do
+      client.expects(:process).with([[:mget, "#{@namespace}:rabbit", "#{@namespace}:white_rabbit"]]).returns(%w[ foo bar ])
+      result = store.mapped_mget "rabbit", "white_rabbit"
+      result.keys.must_equal %w[ rabbit white_rabbit ]
+      result["rabbit"].must_equal "foo"
+      result["white_rabbit"].must_equal "bar"
     end
 
     it "should namespace expire" do


### PR DESCRIPTION
Upstream patch for distributed mget: https://github.com/redis/redis-rb/pull/687

Support passing a block to `mget` like upstream Redis, avoiding double-unmarshaling.

Allows using `Cache#read_multi` and `#fetch_multi`, used in Rails to cache collections of rendered partials, with a distributed Redis store.