### PR TITLE
Add a namespaced version of watch

### DIFF
--- a/lib/redis/store/namespace.rb
+++ b/lib/redis/store/namespace.rb
@@ -43,6 +43,10 @@ class Redis
         super(*keys.map {|key| interpolate(key) }) if keys.any?
       end
 
+      def watch *keys
+        super(*keys.map {|key| interpolate(key) }) if keys.any?
+      end
+
       def mget(*keys)
         options = (keys.pop if keys.last.is_a? Hash) || {}
         if keys.any?

--- a/lib/redis/store/namespace.rb
+++ b/lib/redis/store/namespace.rb
@@ -43,7 +43,7 @@ class Redis
         super(*keys.map {|key| interpolate(key) }) if keys.any?
       end
 
-      def watch *keys
+      def watch(*keys)
         super(*keys.map {|key| interpolate(key) }) if keys.any?
       end
 

--- a/test/redis/store/namespace_test.rb
+++ b/test/redis/store/namespace_test.rb
@@ -155,9 +155,7 @@ describe "Redis::Store::Namespace" do
 
     it "should namespace watch" do
       client.expects(:call).with([:watch,"#{@namespace}:rabbit"]).once
-      store.watch("rabbit") do
-
-      end
+      store.watch("rabbit")
     end
   end
 end

--- a/test/redis/store/namespace_test.rb
+++ b/test/redis/store/namespace_test.rb
@@ -152,5 +152,12 @@ describe "Redis::Store::Namespace" do
        client.expects(:call).with([:ttl, "#{@namespace}:rabbit"]).once
        store.ttl("rabbit")
     end
+
+    it "should namespace watch" do
+      client.expects(:call).with([:watch,"#{@namespace}:rabbit"]).once
+      store.watch("rabbit") do
+
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds a redis.watch with namespaced keys if redis-store instance is using namespaces. 