### PR TITLE
Replace marshalling with pluggable serializers

### DIFF
--- a/lib/redis-store.rb
+++ b/lib/redis-store.rb
@@ -1,13 +1,1 @@
-require 'redis'
 require 'redis/store'
-require 'redis/store/factory'
-require 'redis/distributed_store'
-require 'redis/store/namespace'
-require 'redis/store/marshalling'
-require 'redis/store/version'
-require 'redis/store/redis_version'
-
-class Redis
-  class Store < self
-  end
-end

--- a/lib/redis/store/factory.rb
+++ b/lib/redis/store/factory.rb
@@ -50,7 +50,14 @@ class Redis
         if options.key?(:key_prefix) && !options.key?(:namespace)
           options[:namespace] = options.delete(:key_prefix) # RailsSessionStore
         end
-        options[:raw] = !options[:marshalling]
+        options[:raw] = case
+                        when options.key?(:serializer)
+                          options[:serializer].nil?
+                        when options.key?(:marshalling)
+                          !options[:marshalling]
+                        else
+                          false
+                        end
         options
       end
 

--- a/lib/redis/store/namespace.rb
+++ b/lib/redis/store/namespace.rb
@@ -46,8 +46,8 @@ class Redis
       def mget(*keys)
         options = (keys.pop if keys.last.is_a? Hash) || {}
         if keys.any?
-          # Marshalling gets extended before Namespace does, so we need to pass options further
-          if singleton_class.ancestors.include? Marshalling
+          # Serialization gets extended before Namespace does, so we need to pass options further
+          if singleton_class.ancestors.include? Serialization
             super(*keys.map {|key| interpolate(key) }, options)
           else
             super(*keys.map {|key| interpolate(key) })

--- a/lib/redis/store/serialization.rb
+++ b/lib/redis/store/serialization.rb
@@ -1,6 +1,6 @@
 class Redis
   class Store < self
-    module Marshalling
+    module Serialization
       def set(key, value, options = nil)
         _marshal(value, options) { |v| super encode(key), encode(v), options }
       end
@@ -36,11 +36,11 @@ class Redis
 
       private
         def _marshal(val, options)
-          yield marshal?(options) ? Marshal.dump(val) : val
+          yield marshal?(options) ? @serializer.dump(val) : val
         end
 
         def _unmarshal(val, options)
-          unmarshal?(val, options) ? Marshal.load(val) : val
+          unmarshal?(val, options) ? @serializer.load(val) : val
         end
 
         def marshal?(options)

--- a/test/redis/store/namespace_test.rb
+++ b/test/redis/store/namespace_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe "Redis::Store::Namespace" do
   def setup
     @namespace = "theplaylist"
-    @store  = Redis::Store.new :namespace => @namespace, :marshalling => false # TODO remove mashalling option
+    @store  = Redis::Store.new :namespace => @namespace, :serializer => nil
     @client = @store.instance_variable_get(:@client)
     @rabbit = "bunny"
     @default_store = Redis::Store.new
@@ -90,7 +90,7 @@ describe "Redis::Store::Namespace" do
   end
 
   describe 'method calls' do
-    let(:store){Redis::Store.new :namespace => @namespace, :marshalling => false}
+    let(:store){Redis::Store.new :namespace => @namespace, :serializer => nil}
     let(:client){store.instance_variable_get(:@client)}
 
     it "should namespace get" do

--- a/test/redis/store/serialization_test.rb
+++ b/test/redis/store/serialization_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
-describe "Redis::Marshalling" do
+describe "Redis::Serialization" do
   def setup
-    @store = Redis::Store.new :marshalling => true
+    @store = Redis::Store.new serializer: Marshal
     @rabbit = OpenStruct.new :name => "bunny"
     @white_rabbit = OpenStruct.new :color => "white"
     @store.set "rabbit", @rabbit


### PR DESCRIPTION
This is in response to a vulnerability warning we received on Friday,
August 11th, 2017. While most users will not be affected by this
change, we recommend that developers of new applications use a different
serializer other than `Marshal`. This, along with the removal of the
`:marshalling` option, will enforce "sane defaults" in terms of securely
serializing/de-serializing data.

- Add `:serializer` option and deprecate `:marshalling`. Although you
  will still be able to enable/disable serialization with Marshal using
  `:marshalling` in the 1.x series, this will be removed by 2.0.

- Rename `Redis::Store::Marshalling` to `Redis::Store::Serialization` to
  reflect its new purpose.

Fixes #289.

Shoutout to @Plazmaz for reporting this one and filing for the CVE. Thanks for all your help!