### PR TITLE
Implement cas

### DIFF
--- a/lib/redis/store.rb
+++ b/lib/redis/store.rb
@@ -7,11 +7,12 @@ require 'redis/store/version'
 require 'redis/store/redis_version'
 require 'redis/store/ttl'
 require 'redis/store/interface'
+require 'redis/store/cas'
 require 'redis/store/redis_version'
 
 class Redis
   class Store < self
-    include Ttl, Interface, RedisVersion
+    include Ttl, Interface, RedisVersion, Cas
 
     def initialize(options = { })
       super

--- a/lib/redis/store/cas.rb
+++ b/lib/redis/store/cas.rb
@@ -1,0 +1,106 @@
+class Redis
+  class Store < self
+
+    # Implements Compare-And-Swap (or as Redis says Compare-And-Save)
+    # on top of Redis::Store using Redis::Store::watch. It is designated for simple values, not redis-lists/hashes etc
+    # See https://redis.io/topics/transactions#cas
+    module Cas
+
+      # Single CAS
+      #
+      # Trys to save change the value of a redis-key when it may not done in a atomic matter. Eg, you have do some
+      # checks on old value before setting the new one and so on. If key content changes meanwhile it refuses to
+      # set and you will not overwrite changes from other Thread or Process.
+      #
+      # This method works only on existing keys in redis.
+      # It works only with keys holding a value, eg, read/writeable with get/set
+      #
+      # @yield [value] the current value of given key
+      # @yieldparam [String] key the key to get and set the value
+      # @yieldreturn [String] the new value to store in key
+      # @return [Boolean] true if new value was stored, otherwise false
+      # @param key [String] the key to set. Must not be nil and key must exists in Redis
+      # @param ttl [Integer] if not nil and integer > 0 set a TTL to the changed key
+      # @example
+      #
+      #  storewithcas.cas('examplekey') do |value|
+      #    # value is the CURRENT value!
+      #    new_value = do_some_important_stuff_here(value)
+      #    new_value # write back to redis unless key has changed meanwhile
+      #  end
+      def cas(key, ttl=nil)
+        return false unless exists(key)
+        watch(key) do
+          value = get(key)
+          value = yield value
+          ires = multi do |multi|
+            multi.set(key,value,ttl.nil? ? {} : {:expire_after => ttl})
+          end
+          ires.is_a?(Array) && ires[0] == 'OK'
+        end
+      end
+
+      # Multi CAS
+      #
+      # Safe changing multiple keys at once. It works only with keys holding a value, eg, read/writeable with get/set
+      #
+      # @example
+      #
+      #   storewithcas.cas_multi('key1','key1') do |currenthash|
+      #     newhashedvalues = make_something_with_current(currenthash)
+      #     newhashedvalues
+      #   end
+      #
+      # @example
+      #   storewithcas.cas_multi('k1','k2', :expire_in => 1200) do |currenthash| #=> ttl for all keys swapped
+      #     {'k1' => '1', 'k2' => 2}
+      #   end
+      #
+      # @yield [values] a key=>value hash with values of given keys. keys not existing are not yielded
+      # @yieldparam [Array] keys the keys to change
+      # @yieldreturn [Hash] key-value-pairs to change. Keys not given in parameter or not existing in redis are ignored.
+      # @return [Boolean] true if tried making changes, nil when keylist empty
+      # @param keys [Array] the keys to set. Must not be nil and keys must exists in Redis. After keys list you may append hash with options for redis.
+      def cas_multi(*keys)
+        return if keys.empty?
+        options = extract_options keys
+        watch(*keys) do
+          values = read_multi(*keys,options)
+          valuehash = yield values
+          valuehash.map do |name,value|
+            multi do |multi|
+              multi.set(name,value,options)
+            end if values.key?(name)
+          end
+          true
+        end
+      end
+
+      # Read list of keys and return values as Hash
+      #
+      # @param keys Array the keys to read
+      # @return [Hash] key-value-pairs of key found in redis, eg, exists.
+      #
+      # @example
+      #  values = read_multi("key1","key2","key3") #=> {"key1" => "1", "key2" => "2", "key3" => "3"}
+      def read_multi(*keys)
+        options = extract_options keys
+        keys = keys.select {|k| exists(k)}
+        return {} if keys.empty?
+        values = mget(*keys,options)
+        values.nil? ? {} : Hash[keys.zip(values)]
+      end
+
+      private
+
+      def extract_options(array)
+        if array.last.is_a?(Hash) && array.last.instance_of?(Hash)
+          array.pop
+        else
+          {}
+        end
+      end
+    end
+
+  end
+end

--- a/test/redis/store/cas_test.rb
+++ b/test/redis/store/cas_test.rb
@@ -1,0 +1,127 @@
+require 'test_helper'
+
+describe "Redis::Store::Cas" do
+  def setup
+    @store  = Redis::Store.new :namespace => 'storetest'
+  end
+
+  def teardown
+    @store.flushdb
+    @store.quit
+  end
+
+  def test_cas
+    @store.set('foo', 'baz')
+    assert(@store.cas('foo') do |value|
+      assert_equal 'baz', value
+      'bar'
+    end)
+    assert_equal 'bar', @store.get('foo')
+  end
+
+  def test_cas_with_cache_miss
+    refute @store.cas('not_exist') { |_value| flunk }
+  end
+
+  def test_cas_with_conflict
+    @store.set('foo', 'bar')
+    refute @store.cas('foo') { |_value|
+      @store.set('foo', 'baz')
+      'biz'
+    }
+    assert_equal 'baz', @store.get('foo')
+  end
+
+  # TODO write a Mockup redis with support for watch
+  def test_cas_with_ttl
+    @store.set('ttlfoo','bar')
+    assert(@store.cas('ttlfoo',3600) do |value|
+      assert_equal 'bar',value
+      'ttlbar'
+    end)
+    assert_equal @store.get('ttlfoo'),'ttlbar'
+    assert @store.ttl('ttlfoo') > 0
+    assert(@store.cas('ttlfoo') do |value|
+      'bar'
+    end)
+    assert_equal -1,@store.ttl('ttlfoo')
+  end
+
+  def test_cas_multi_with_empty_set
+    refute @store.cas_multi { |_hash| flunk }
+  end
+
+
+  def test_read_multi
+    @store.set('k1','m1')
+    @store.set('k2','m2')
+    assert_equal({"k1" => "m1","k2" => "m2"},@store.read_multi("k1","k2"))
+  end
+
+  def test_cas_multi
+    @store.set('foo', 'bar')
+    @store.set('fud', 'biz')
+    assert_equal true, (@store.cas_multi('foo', 'fud') do |hash|
+      assert_equal({ "foo" => "bar", "fud" => "biz" }, hash)
+      { "foo" => "baz", "fud" => "buz" }
+    end)
+    assert_equal({ "foo" => "baz", "fud" => "buz" }, @store.read_multi('foo', 'fud'))
+  end
+
+  def test_cas_multi_with_ttl
+    @store.set('foo', 'bar')
+    @store.set('fud', 'biz')
+    @store.cas_multi('foo','fud',{:expires_in => 3600}) do |hash|
+      { "foo" => "baz", "fud" => "buz" }
+    end
+    assert @store.ttl('foo') > 0
+    assert @store.ttl('fud') > 0
+  end
+
+  def test_cas_multi_with_cache_miss
+    assert(@store.cas_multi('not_exist') do |hash|
+      assert hash.empty?
+      {}
+    end)
+  end
+
+  def test_cas_multi_with_altered_key
+    @store.set('foo', 'baz')
+    assert @store.cas_multi('foo') { |_hash| { 'fu' => 'baz' } }
+    assert_nil @store.get('fu')
+    assert_equal 'baz', @store.get('foo')
+  end
+
+  def test_cas_multi_with_partial_miss
+    @store.set('foo', 'baz')
+    assert(@store.cas_multi('foo', 'bar') do |hash|
+      assert_equal({ "foo" => "baz" }, hash)
+      {}
+    end)
+    assert_equal 'baz', @store.get('foo')
+  end
+
+  def test_cas_multi_with_partial_update
+    @store.set('foo', 'bar')
+    @store.set('fud', 'biz')
+    assert(@store.cas_multi('foo', 'fud') do |hash|
+      assert_equal({ "foo" => "bar", "fud" => "biz" }, hash)
+
+      { "foo" => "baz" }
+    end)
+    assert_equal({ "foo" => "baz", "fud" => "biz" }, @store.read_multi('foo', 'fud'))
+  end
+
+  def test_cas_multi_with_partial_conflict
+    @store.set('foo', 'bar')
+    @store.set('fud', 'biz')
+    result = @store.cas_multi('foo', 'fud') do |hash|
+      assert_equal({ "foo" => "bar", "fud" => "biz" }, hash)
+      @store.set('foo', 'bad')
+      { "foo" => "baz", "fud" => "buz" }
+    end
+    assert result
+    assert_equal({ "foo" => "bad", "fud" => "buz" }, @store.read_multi('foo', 'fud'))
+  end
+
+end


### PR DESCRIPTION
this request implements Compare-And-Save or Compare-And-Swap support for redis-store. 

In https://redis.io/topics/transactions#cas it is described what it should do. 

Mostly it may used with caching data from within multiple threads/processes. 

The first implementation was a work done for integrating IdentityCache (https://github.com/Shopify/identity_cache) into a (nonpublic) RAILS project not using memcached but redis.

Methods are commented so it should be clear what them are doing, testcases are integrated, too.