### PR TITLE
Add :avoid_multi_commands to use pipelined over multi command

### DIFF
--- a/test/redis/store/ttl_test.rb
+++ b/test/redis/store/ttl_test.rb
@@ -95,8 +95,7 @@ describe MockTtlStore do
       end
 
       it 'must not call expire' do
-        MockTtlStore.any_instance.expects(:expire).never
-
+        redis.expects(:expire).never
         redis.setnx(key, mock_value)
       end
     end


### PR DESCRIPTION
`multi` is not supported by all redis cluster proxies. Redis cluster by itself should work because we're using the same key twice, but using it behind a proxy is not supported right now. By adding `:avoid_multi_commands` we can pick between `pipelined` and `multi` so we can support both scenarios.

I don't love the config name (I'm horrible at naming things), but wanted to push some code up to get some eyes on it.

Note: I used the existing `MockRedis` class to test between `piplelined` and `multi` because I don't think mocha has a "expect and call original" like rspec does.

Question: I noticed the current release is `v1.4.0` but `redis-rack` and others are locked down to `1.3.0`. Just wondering if you're waiting on something before unlocking those. Thanks!

Edit: I just saw there's a commit in `redis-rack` master relaxing the version. 👌 

cc @tubbo  