### PR TITLE
CI: Float on major Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,19 @@
 language: ruby
 sudo: false
 cache: bundler
+
+# 1.9.3 has Bundler 1.7.6 with the "undefined method `spec' for nil" bug
 before_install: gem install bundler
-script: 'bundle exec rake'
+
 rvm:
   - 1.9.3
-  - 2.0.0
+  - 2.0
   - 2.1
   - 2.2
-  - 2.3.0
+  - 2.3
+  - 2.4
   - ruby-head
   - jruby-head
-bundler_args: '--path vendor/bundle'
 
 matrix:
   allow_failures:

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,7 @@
 source 'https://rubygems.org'
+
+if RUBY_VERSION < '2'
+  gem 'redis', '< 4'
+end
+
 gemspec


### PR DESCRIPTION
* Test against latest minor for each major release
* Drop bundler handling that Travis does by default already