### PR TITLE
Add RuboCop and define style guide

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,6 @@
+---
+plugins:
+  rubocop:
+    enabled: true
+  fixme:
+    enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,187 @@
+---
+AllCops:
+  TargetRubyVersion: 2.4
+  # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
+  # to ignore them, so only the ones explicitly set in this file are enabled.
+  DisabledByDefault: true
+  Exclude:
+    - '**/templates/**/*'
+    - '**/vendor/**/*'
+    - 'actionpack/lib/action_dispatch/journey/parser.rb'
+
+# Prefer &&/|| over and/or.
+Style/AndOr:
+  Enabled: true
+
+# Do not use braces for hash literals when they are the last argument of a
+# method call.
+Style/BracesAroundHashParameters:
+  Enabled: true
+  EnforcedStyle: context_dependent
+  Exclude:
+    - 'lib/redis/distributed_store.rb'
+    - 'test/redis/store/factory_test.rb'
+
+# Align comments with method definitions.
+Layout/CommentIndentation:
+  Enabled: true
+
+Layout/ElseAlignment:
+  Enabled: true
+
+Layout/EmptyLineAfterMagicComment:
+  Enabled: true
+  Exclude:
+    - 'redis-store.gemspec'
+
+# In a regular class definition, no empty lines around the body.
+Layout/EmptyLinesAroundClassBody:
+  Enabled: true
+  Exclude:
+    - 'lib/redis/store/factory.rb'
+    - 'test/redis/store/ttl_test.rb'
+
+# In a regular method definition, no empty lines around the body.
+Layout/EmptyLinesAroundMethodBody:
+  Enabled: true
+
+# In a regular module definition, no empty lines around the body.
+Layout/EmptyLinesAroundModuleBody:
+  Enabled: true
+
+Layout/FirstParameterIndentation:
+  Enabled: true
+
+# Method definitions after `private` or `protected` isolated calls need one
+# extra level of indentation.
+Layout/IndentationConsistency:
+  Enabled: true
+  EnforcedStyle: rails
+
+# Two spaces, no tabs (for indentation).
+Layout/IndentationWidth:
+  Enabled: true
+  Exclude:
+    - 'lib/redis/store/factory.rb'
+    - 'lib/redis/store/namespace.rb'
+    - 'test/redis/store/namespace_test.rb'
+
+Layout/LeadingCommentSpace:
+  Enabled: true
+
+Layout/SpaceAfterColon:
+  Enabled: true
+
+Layout/SpaceAfterComma:
+  Enabled: true
+  Exclude:
+    - 'test/redis/store/namespace_test.rb'
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: true
+
+Layout/SpaceAroundKeyword:
+  Enabled: true
+
+Layout/SpaceAroundOperators:
+  Enabled: true
+  Exclude:
+    - 'test/redis/store/redis_version_test.rb'
+
+Layout/SpaceBeforeComma:
+  Enabled: true
+
+Layout/SpaceBeforeFirstArg:
+  Enabled: true
+
+Style/DefWithParentheses:
+  Enabled: true
+
+# Defining a method with parameters needs parentheses.
+Style/MethodDefParentheses:
+  Enabled: true
+
+# Use `foo {}` not `foo{}`.
+Layout/SpaceBeforeBlockBraces:
+  Enabled: true
+  Exclude:
+    - 'lib/redis/store/namespace.rb'
+    - 'redis-store.gemspec'
+    - 'test/redis/store/namespace_test.rb'
+
+# Use `foo { bar }` not `foo {bar}`.
+Layout/SpaceInsideBlockBraces:
+  Enabled: true
+  Exclude:
+    - 'lib/redis/distributed_store.rb'
+    - 'lib/redis/store/factory.rb'
+    - 'lib/redis/store/namespace.rb'
+    - 'test/redis/store/factory_test.rb'
+    - 'test/redis/store/namespace_test.rb'
+
+# Use `{ a: 1 }` not `{a:1}`.
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: true
+  Exclude:
+    - 'lib/redis/distributed_store.rb'
+    - 'lib/redis/store.rb'
+    - 'test/redis/distributed_store_test.rb'
+    - 'test/redis/store/factory_test.rb'
+    - 'test/redis/store/serialization_test.rb'
+    - 'test/redis/store/ttl_test.rb'
+
+Layout/SpaceInsideParens:
+  Enabled: true
+
+# Detect hard tabs, no hard tabs.
+Layout/Tab:
+  Enabled: true
+
+# Blank lines should not have any spaces.
+Layout/TrailingBlankLines:
+  Enabled: true
+  Exclude:
+    - 'lib/redis/store.rb'
+    - 'lib/redis/store/redis_version.rb'
+    - 'test/redis/store/redis_version_test.rb'
+
+# No trailing whitespace.
+Layout/TrailingWhitespace:
+  Enabled: true
+  Exclude:
+    - 'lib/redis/distributed_store.rb'
+    - 'lib/redis/store/factory.rb'
+    - 'test/redis/store/factory_test.rb'
+
+# Use quotes for string literals when they are enough.
+Style/UnneededPercentQ:
+  Enabled: true
+
+# Align `end` with the matching keyword or starting expression except for
+# assignments, where it should be aligned with the LHS.
+Layout/EndAlignment:
+  Enabled: true
+  EnforcedStyleAlignWith: variable
+  AutoCorrect: true
+  Exclude:
+    - 'lib/redis/store/factory.rb'
+
+# Use my_method(my_arg) not my_method( my_arg ) or my_method my_arg.
+Lint/RequireParentheses:
+  Enabled: true
+
+Style/RedundantReturn:
+  Enabled: true
+  AllowMultipleReturnValues: true
+  Exclude:
+    - 'test/test_helper.rb'
+
+Style/Semicolon:
+  Enabled: true
+  AllowAsExpressionSeparator: true
+
+# Prefer Foo.method over Foo::method
+Style/ColonMethodCall:
+  Enabled: true
+  Exclude:
+    - 'lib/redis/store/factory.rb'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,14 @@ notifications:
   webhooks: https://www.travisbuddy.com
   on_success: never
 
-# 1.9.3 has Bundler 1.7.6 with the "undefined method `spec' for nil" bug
-before_install: gem install bundler
+before_install:
+  # Install node version from .nvmrc
+  - nvm install
+  # Install Code Climate test reporter
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  # 1.9.3 has Bundler 1.7.6 with the "undefined method `spec' for nil" bug
+  - gem install bundler
 
 rvm:
   - 1.9.3
@@ -21,6 +27,11 @@ rvm:
 gemfile:
   - gemfiles/redis_3_x.gemfile
   - gemfiles/redis_4_x.gemfile
+
+# Pipe the coverage data to Code Climate if tests pass
+after_script:
+  - ./cc-test-reporter format-coverage -t simplecov -o coverage/codeclimate.json
+  - if [[ "$TRAVIS_TEST_RESULT" == 0 ]]; then ./cc-test-reporter upload-coverage; fi  # Upload coverage/codeclimate.json
 
 matrix:
   allow_failures:

--- a/redis-store.gemspec
+++ b/redis-store.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |s|
   s.authors     = ['Luca Guidi']
   s.email       = ['me@lucaguidi.com']
   s.homepage    = 'http://redis-store.org/redis-store'
-  s.summary     = %q{Redis stores for Ruby frameworks}
-  s.description = %q{Namespaced Rack::Session, Rack::Cache, I18n and cache Redis stores for Ruby web frameworks.}
+  s.summary     = 'Redis stores for Ruby frameworks'
+  s.description = 'Namespaced Rack::Session, Rack::Cache, I18n and cache Redis stores for Ruby web frameworks.'
 
   s.rubyforge_project = 'redis-store'
 
@@ -30,4 +30,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry',      '~> 0.10.4'
   s.add_development_dependency 'redis-store-testing'
   s.add_development_dependency 'appraisal', '~> 2.0'
+  s.add_development_dependency 'rubocop', '~> 0.54'
 end

--- a/test/redis/store/interface_test.rb
+++ b/test/redis/store/interface_test.rb
@@ -10,18 +10,18 @@ describe Redis::Store::Interface do
   end
 
   it "should get an element" do
-    lambda { @r.get("key", :option => true) } #.wont_raise ArgumentError
+    lambda { @r.get("key", :option => true) } # .wont_raise ArgumentError
   end
 
   it "should set an element" do
-    lambda { @r.set("key", "value", :option => true) } #.wont_raise ArgumentError
+    lambda { @r.set("key", "value", :option => true) } # .wont_raise ArgumentError
   end
 
   it "should setnx an element" do
-    lambda { @r.setnx("key", "value", :option => true) } #.wont_raise ArgumentError
+    lambda { @r.setnx("key", "value", :option => true) } # .wont_raise ArgumentError
   end
 
   it "should setex an element" do
-    lambda { @r.setex("key", 1, "value", :option => true) } #.wont_raise ArgumentError
+    lambda { @r.setex("key", 1, "value", :option => true) } # .wont_raise ArgumentError
   end
 end


### PR DESCRIPTION
The style guide used here is based off of Rails' `.rubocop.yml`, and has
some exceptions for existing infractions. From this point forward, we're
going to keep to the style enforced through CodeClimate and RuboCop.

- Define style guide in `.rubocop.yml`
- Make some low-hanging-fruit corrections
- Configure CodeClimate to run RuboCop lint checks
- Configure Travis CI to report test coverage data to CodeClimate