### PR TITLE
Honor rediss:// schemes in URI

### DIFF
--- a/lib/redis/store/factory.rb
+++ b/lib/redis/store/factory.rb
@@ -75,6 +75,7 @@ class Redis
                              end
 
           options = {
+            :scheme   => uri.scheme,
             :host     => uri.hostname,
             :port     => uri.port || DEFAULT_PORT,
             :password => uri.password.nil? ? nil : CGI::unescape(uri.password.to_s)

--- a/test/redis/store/factory_test.rb
+++ b/test/redis/store/factory_test.rb
@@ -208,6 +208,11 @@ describe "Redis::Store::Factory" do
         store.to_s.must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist")
       end
 
+      it 'honors scheme (rediss:// vs. redis://)' do
+        store = Redis::Store::Factory.create "rediss://127.0.0.1:6380"
+        store.instance_variable_get(:@client).scheme.must_equal('rediss')
+      end
+
       it 'instantiates Redis::DistributedStore and merges options' do 
         store = Redis::Store::Factory.create "redis://127.0.0.1:6379", "redis://127.0.0.1:6380", { :namespace => 'theplaylist' }
         store.nodes.map {|node| node.to_s }.must_equal([


### PR DESCRIPTION
Currently, if a URI string is used to create a Redis::Store::Factory, the scheme of the URI will be ignored (and will default to `redis`). This update allows `redis://` URIs to be passed and work as expected.

cc: @jamesdempsey