### PR TITLE
Support namespacing in Redis::Store#unlink

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ rvm:
   - jruby-head
 
 gemfile:
-  - gemfiles/redis_3_x.gemfile
   - gemfiles/redis_4_x.gemfile
 
 before_script: ./cc-test-reporter before-build

--- a/lib/redis/store/namespace.rb
+++ b/lib/redis/store/namespace.rb
@@ -43,6 +43,10 @@ class Redis
         super(*keys.map { |key| interpolate(key) }) if keys.any?
       end
 
+      def unlink(*keys)
+        super(*keys.map { |key| interpolate(key) }) if keys.any?
+      end
+
       def watch(*keys)
         super(*keys.map { |key| interpolate(key) }) if keys.any?
       end

--- a/lib/redis/store/version.rb
+++ b/lib/redis/store/version.rb
@@ -1,5 +1,5 @@
 class Redis
   class Store < self
-    VERSION = '1.6.0'
+    VERSION = '1.7.0'
   end
 end

--- a/redis-store.gemspec
+++ b/redis-store.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.license       = 'MIT'
 
-  s.add_dependency 'redis', '>= 2.2', '< 5'
+  s.add_dependency 'redis', '>= 4', '< 5'
 
   s.add_development_dependency 'rake',     '~> 10'
   s.add_development_dependency 'bundler',  '~> 1.3'


### PR DESCRIPTION
Ensures the keys given to `Redis::Store#unlink` are namespaced according
to the global configuration passed in at instantiation. Allow
downstream components to use the `UNLINK` command in Redis 4 instead of
`DEL`, since it is more performant. Also, update the Redis client to
4.0.0 or above.

Fixes #311 