### PR TITLE
Lock down Bundler to v1.16.1 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   # 1.9.3 has Bundler 1.7.6 with the "undefined method `spec' for nil" bug
-  - gem install bundler
+  - gem install bundler -v 1.16.1
 
 rvm:
   - 2.1


### PR DESCRIPTION
After Bundler v2.0 was released I noticed that my PR on markevans/dragonfly failed because Bundler v2.0 was being installed on Ruby versions older than v2.3.x. This ensures that tests will still execute on older Ruby versions, because Bundler v1.16.x still works everywhere you need it to be.