### PR TITLE
Add Cluster Support

### DIFF
--- a/lib/redis/store/ttl.rb
+++ b/lib/redis/store/ttl.rb
@@ -34,7 +34,7 @@ class Redis
         end
 
         def with_multi_or_pipelined(options, &block)
-          return pipelined(&block) if options[:avoid_multi_commands]
+          return pipelined(&block) if options.key?(:cluster) || options[:avoid_multi_commands]
           multi(&block)
         end
     end

--- a/test/redis/store/ttl_test.rb
+++ b/test/redis/store/ttl_test.rb
@@ -133,6 +133,25 @@ describe MockTtlStore do
           redis.has_expire?(key, options[:expire_after]).must_equal true
         end
       end
+
+      describe 'using a redis cluster' do
+        let(:options) { { :expire_after => 3600, :cluster => %w[redis://127.0.0.1:6379/0] } }
+
+        it 'uses the redis pipelined feature to chain commands' do
+          redis.expects(:pipelined)
+          redis.setnx(key, mock_value, options)
+        end
+
+        it 'must call setnx with key and value and set raw to true' do
+          redis.setnx(key, mock_value, options)
+          redis.has_setnx?(key, mock_value, :raw => true).must_equal true
+        end
+
+        it 'must call expire' do
+          redis.setnx(key, mock_value, options)
+          redis.has_expire?(key, options[:expire_after]).must_equal true
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Now that the official Redis client has clustering support, there's no
real use for the `:avoid_multi_commands` option, but it will be kept
around until the next major version. You can now just set your Array of
cluster URLs like so...

    cluster: %w[redis://first.host:6379 redis://second.host:6379]

...and the `#pipelined` method will be used to send commands over to
Redis.

This allows redis-store/redis-rails#93 to get merged.