### PR TITLE
Resolve Travis Bundler Issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,5 @@ matrix:
   exclude:
     - rvm: 2.1
       gemfile: gemfiles/redis_4_x.gemfile
+    - rvm: 2.2
+      gemfile: gemfiles/redis_4_x.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ before_install:
   # Install Code Climate test reporter
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
-  # 1.9.3 has Bundler 1.7.6 with the "undefined method `spec' for nil" bug
-  - gem install bundler
 
 rvm:
   - 2.1

--- a/redis-store.gemspec
+++ b/redis-store.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'redis', '>= 2.2', '< 5'
 
   s.add_development_dependency 'rake',     '~> 10'
-  s.add_development_dependency 'bundler',  '~> 1.3'
+  s.add_development_dependency 'bundler'
   s.add_development_dependency 'mocha',    '~> 0.14.0'
   s.add_development_dependency 'minitest', '~> 5'
   s.add_development_dependency 'git',      '~> 1.2'


### PR DESCRIPTION
This allows any version of Bundler to be used to install dependencies for Redis::Store. There's no real reason to require version 1.3 or above in the gemspec, and we aren't checking in `Gemfile.lock` so conflicts can't emerge from the `BUNDLED_WITH` instruction.