### PR TITLE
Add Namespace to hscan, hdel, and hlen

### DIFF
--- a/lib/redis/store/namespace.rb
+++ b/lib/redis/store/namespace.rb
@@ -90,6 +90,18 @@ class Redis
         namespace(key) { |k| super(k, ttl) }
       end
 
+      def hscan(key, cursor, options = {})
+        namespace(key) { |k| super(k, cursor, options) }
+      end
+
+      def hdel(key, *fields)
+        namespace(key) { |k| super(k, fields) }
+      end
+
+      def hlen(key)
+        namespace(key) { |k| super(k) }
+      end
+
       def to_s
         if namespace_str
           "#{super} with namespace #{namespace_str}"

--- a/test/redis/store/namespace_test.rb
+++ b/test/redis/store/namespace_test.rb
@@ -208,5 +208,20 @@ describe "Redis::Store::Namespace" do
       client.expects(:call).with([:hset, "#{@namespace}:rabbit", "key", @rabbit])
       store.hset("rabbit", "key", @rabbit)
     end
+
+    it "should namespace hscan" do
+      client.expects(:call).with([:hscan, "#{@namespace}:rabbit", 0])
+      store.hscan("rabbit", 0)
+    end
+
+    it "should namespace hdel" do
+      client.expects(:call).with([:hdel, "#{@namespace}:rabbit", %w(field)])
+      store.hdel("rabbit", "field")
+    end
+
+    it "should namespace hlen" do
+      client.expects(:call).with([:hlen, "#{@namespace}:rabbit"])
+      store.hlen("rabbit")
+    end
   end
 end


### PR DESCRIPTION
Rounds out the hash methods that are namespaced and ensures that all
results are consistent. Thanks @ruanltbg for the implementation code!

Fixes #320