### PR TITLE
namespaces for zadd and zrem do not support multiple members and scores

### DIFF
--- a/lib/redis/store/namespace.rb
+++ b/lib/redis/store/namespace.rb
@@ -150,8 +150,8 @@ class Redis
         namespace(key) { |k| super(k, member) }
       end
 
-      def zadd(key, increment, member)
-        namespace(key) { |k| super(k, increment, member) }
+      def zadd(key, *args)
+        namespace(key) { |k| super(k, *args) }
       end
 
       def zrem(key, member)


### PR DESCRIPTION
the redis api for zadd is:  def zadd(key, *args) and supports adding multiple members and scores.  The namespace defines these as taking 3 arguments which only allows for adding a single member and score: def zadd(key, increment, member).

redis/store/namespace.rb

Thanks @alrooney!