### PR TITLE
Allow unserializing in pipeline

### DIFF
--- a/lib/redis/store/interface.rb
+++ b/lib/redis/store/interface.rb
@@ -1,8 +1,10 @@
 class Redis
   class Store < self
     module Interface
-      def get(key, options = nil)
-        super(key)
+      def get(key, options = nil, &blk)
+        synchronize do |client|
+          client.call([:get, key], &blk)
+        end
       end
 
       def set(key, value, options = nil)

--- a/lib/redis/store/serialization.rb
+++ b/lib/redis/store/serialization.rb
@@ -14,7 +14,13 @@ class Redis
       end
 
       def get(key, options = nil)
-        _unmarshal super(key), options
+        if @client.is_a?(Pipeline)
+          super(key) do |reply|
+            _unmarshal reply, options
+          end
+        else
+          _unmarshal super(key), options
+        end
       end
 
       def mget(*keys, &blk)

--- a/test/redis/store/serialization_test.rb
+++ b/test/redis/store/serialization_test.rb
@@ -18,6 +18,16 @@ describe "Redis::Serialization" do
     @store.get("rabbit").must_equal(@rabbit)
   end
 
+  it "unmarshals on get in pipeline" do
+    rabbit = nil
+
+    @store.pipelined do
+      rabbit = @store.get("rabbit")
+    end
+
+    rabbit.value.must_equal(@rabbit)
+  end
+
   it "marshals on set" do
     @store.set "rabbit", @white_rabbit
     @store.get("rabbit").must_equal(@white_rabbit)
@@ -105,6 +115,17 @@ describe "Redis::Serialization" do
       rabbit.must_equal(@rabbit)
       rabbit2.must_equal(@white_rabbit)
     end
+  end
+
+  it "unmarshals on multi get in pipeline" do
+    rabbits = nil
+    @store.set "rabbit2", @white_rabbit
+
+    @store.pipelined do
+      rabbits = @store.mget("rabbit", "rabbit2")
+    end
+
+    rabbits.value.must_equal([@rabbit, @white_rabbit])
   end
 
   it "unmarshals on mapped_mget" do


### PR DESCRIPTION
## problem

When using `#get` inside a pipeline, I get the error 

```
NoMethodError: undefined method `size' for <Redis::Future
```

This happens because `Redis::Store` does not handle the case when inside `pipelined` block, the result of `get` is a `Future` object instead of the raw value.

## fix

- `Future` object requires a block to be passed in, to serialize data correctly. However, the current implementation of `Redis#get` does not allow a block to be passed in.
- I currently have no solution other than copying the code from `Redis#get` and add support for block in `interface.rb`. I would love to know if there are better ways.

- There is a work around by using `mget`, I wonder if it is sufficient?  If it is, should we add a comment so that people avoid using `Redis::Store#get` inside pipeline?