### PR TITLE
Fix compatibility with redis-rb 4.2

### DIFF
--- a/lib/redis/store/interface.rb
+++ b/lib/redis/store/interface.rb
@@ -5,8 +5,16 @@ class Redis
         super(key)
       end
 
+      REDIS_SET_OPTIONS = %i(ex px nx xx keepttl).freeze
+      private_constant :REDIS_SET_OPTIONS
+
       def set(key, value, options = nil)
-        super(key, value, options || {})
+        if options && REDIS_SET_OPTIONS.any? { |k| options.key?(k) }
+          kwargs = REDIS_SET_OPTIONS.each_with_object({}) { |key, h| h[key] = options[key] if options.key?(key) }
+          super(key, value, **kwargs)
+        else
+          super(key, value)
+        end
       end
 
       def setnx(key, value, options = nil)

--- a/lib/redis/store/namespace.rb
+++ b/lib/redis/store/namespace.rb
@@ -23,8 +23,12 @@ class Redis
         namespace(key) { |k| super(k, options) }
       end
 
-      def exists(key)
-        namespace(key) { |k| super(k) }
+      def exists(*keys)
+        super(*keys.map { |key| interpolate(key) })
+      end
+
+      def exists?(*keys)
+        super(*keys.map { |key| interpolate(key) })
       end
 
       def incrby(key, increment)
@@ -118,8 +122,8 @@ class Redis
         namespace(key) { |k| super(k, *attrs) }
       end
 
-      def hset(key, field, val)
-        namespace(key) { |k| super(k, field, val) }
+      def hset(key, *args)
+        namespace(key) { |k| super(k, *args) }
       end
 
       def hsetnx(key, field, val)


### PR DESCRIPTION
Fix https://github.com/redis-store/redis-actionpack/issues/31

The code is a bit convoluted because of the ruby 2.1 requirement. on 2.5+ I could have used Hash#slice.

cc @tubbo @shepmaster