### PR TITLE
Fix Incompatibility with Redis::Rack

### DIFF
--- a/lib/redis/store/interface.rb
+++ b/lib/redis/store/interface.rb
@@ -9,7 +9,7 @@ class Redis
       private_constant :REDIS_SET_OPTIONS
 
       def set(key, value, options = nil)
-        if options && REDIS_SET_OPTIONS.any? { |k| options.key?(k) }
+        if options && REDIS_SET_OPTIONS.any? { |k| _option_key?(k) }
           kwargs = REDIS_SET_OPTIONS.each_with_object({}) do |key, hash|
             hash[key] = options[key] if _option_key?(options, key)
           end

--- a/lib/redis/store/interface.rb
+++ b/lib/redis/store/interface.rb
@@ -10,7 +10,10 @@ class Redis
 
       def set(key, value, options = nil)
         if options && REDIS_SET_OPTIONS.any? { |k| options.key?(k) }
-          kwargs = REDIS_SET_OPTIONS.each_with_object({}) { |key, h| h[key] = options[key] if options.key?(key) }
+          kwargs = REDIS_SET_OPTIONS.each_with_object({}) do |key, hash|
+            hash[key] = options[key] if _option_key?(options, key)
+          end
+
           super(key, value, **kwargs)
         else
           super(key, value)
@@ -24,6 +27,16 @@ class Redis
       def setex(key, expiry, value, options = nil)
         super(key, expiry, value)
       end
+
+      private
+
+        def _option_key?(options, name)
+          if options.respond_to? :key?
+            options.key? name
+          else
+            !options[name].nil?
+          end
+        end
     end
   end
 end


### PR DESCRIPTION
Alter the check for a key in `options` based on whether the object actually responds to `:key?`, which `ActionDispatch::Request::Session::Options` does not seem to implement.

Fixes #336