### PR TITLE
Fix Incompatibility with Redis::Rack

### DIFF
--- a/lib/redis/store/interface.rb
+++ b/lib/redis/store/interface.rb
@@ -9,8 +9,11 @@ class Redis
       private_constant :REDIS_SET_OPTIONS
 
       def set(key, value, options = nil)
-        if options && REDIS_SET_OPTIONS.any? { |k| options.key?(k) }
-          kwargs = REDIS_SET_OPTIONS.each_with_object({}) { |key, h| h[key] = options[key] if options.key?(key) }
+        if options && REDIS_SET_OPTIONS.any? { |k| _option_key?(options, k) }
+          kwargs = REDIS_SET_OPTIONS.each_with_object({}) do |key, hash|
+            hash[key] = options[key] if _option_key?(options, key)
+          end
+
           super(key, value, **kwargs)
         else
           super(key, value)
@@ -24,6 +27,16 @@ class Redis
       def setex(key, expiry, value, options = nil)
         super(key, expiry, value)
       end
+
+      private
+
+        def _option_key?(options, name)
+          if options.respond_to? :key?
+            options.key? name
+          else
+            !options[name].nil?
+          end
+        end
     end
   end
 end

--- a/test/redis/store/interface_test.rb
+++ b/test/redis/store/interface_test.rb
@@ -4,24 +4,42 @@ class InterfacedRedis < Redis
   include Redis::Store::Interface
 end
 
+class CustomOptions
+  def initialize(options)
+    @delegate = options.dup
+  end
+
+  def [](key)
+    @delegate[key]
+  end
+end
+
 describe Redis::Store::Interface do
   before do
     @r = InterfacedRedis.new
   end
 
   it "should get an element" do
-    lambda { @r.get("key", :option => true) } # .wont_raise ArgumentError
+    @r.get("key", :option => true) # .wont_raise ArgumentError
   end
 
-  it "should set an element" do
-    lambda { @r.set("key", "value", :option => true) } # .wont_raise ArgumentError
+  it "should set an element without options" do
+    @r.set("key", "value") # .wont_raise ArgumentError
+  end
+
+  it "should set an element with options" do
+    @r.set("key", "value", :option => true) # .wont_raise ArgumentError
+  end
+
+  it "should set an element with custom options object" do
+    @r.set("key", "value", CustomOptions.new(:option => true)) # .wont_raise ArgumentError
   end
 
   it "should setnx an element" do
-    lambda { @r.setnx("key", "value", :option => true) } # .wont_raise ArgumentError
+    @r.setnx("key", "value", :option => true) # .wont_raise ArgumentError
   end
 
   it "should setex an element" do
-    lambda { @r.setex("key", 1, "value", :option => true) } # .wont_raise ArgumentError
+    @r.setex("key", 1, "value", :option => true) # .wont_raise ArgumentError
   end
 end


### PR DESCRIPTION
Alter the check for a key in `options` based on whether the object
actually responds to `:key?`, which `ActionDispatch::Request::Session::Options`
does not seem to implement.

Also fixes the test cases for interface

Fixes #336

Copied from #337 and replaces it