### PR TITLE
Interpolate namespace when calling mset

### DIFF
--- a/lib/redis/store/namespace.rb
+++ b/lib/redis/store/namespace.rb
@@ -78,6 +78,16 @@ class Redis
         end
       end
 
+      def mset(*args)
+        options = (args.pop if args.last.is_a? Hash) || {}
+
+        updates = args.each_slice(2).map do |key, value|
+          [interpolate(key), value]
+        end.flatten
+
+        super(*updates, **options)
+      end
+
       def expire(key, ttl)
         namespace(key) { |k| super(k, ttl) }
       end

--- a/test/redis/store/namespace_test.rb
+++ b/test/redis/store/namespace_test.rb
@@ -156,6 +156,11 @@ describe "Redis::Store::Namespace" do
       end
     end
 
+    it "should namespace mset" do
+      client.expects(:call).with([:mset, "#{@namespace}:rabbit", 1, "#{@namespace}:white_rabbit", 2, {}])
+      store.mset "rabbit", 1, "white_rabbit", 2
+    end
+
     it "should namespace mapped_mget" do
       client.expects(:process).with([[:mget, "#{@namespace}:rabbit", "#{@namespace}:white_rabbit"]]).returns(%w[ foo bar ])
       result = store.mapped_mget "rabbit", "white_rabbit"


### PR DESCRIPTION
When calling `mset`, namespace isn't interpolated, so the keys cannot be set properly in redis store. 

### Before

```ruby
store = Redis::Store::Factory.create('redis://localhost:6379/1/sessions')
store.mset("rabbit", 1)
store.get("rabbit") # => nil
```

### After

```ruby
store = Redis::Store::Factory.create('redis://localhost:6379/1/sessions')
store.mset("rabbit", 1)
store.get("rabbit") # => 1
```