### PR TITLE
chore: drop unused gemspec directives

### DIFF
--- a/redis-store.gemspec
+++ b/redis-store.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |s|
   s.description = 'Namespaced Rack::Session, Rack::Cache, I18n and cache Redis stores for Ruby web frameworks.'
 
   s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
   s.license       = 'MIT'
 


### PR DESCRIPTION
- this gem exposes no executables.
- rubygems.org does nothing with test_file