### PR TITLE
Fix deprecated uses of `Redis#pipelined` and `Redis#multi`

### DIFF
--- a/lib/redis/store/ttl.rb
+++ b/lib/redis/store/ttl.rb
@@ -19,9 +19,9 @@ class Redis
 
       protected
         def setnx_with_expire(key, value, ttl, options = {})
-          with_multi_or_pipelined(options) do
-            setnx(key, value, :raw => true)
-            expire(key, ttl)
+          with_multi_or_pipelined(options) do |transaction|
+            transaction.setnx(key, value, :raw => true)
+            transaction.expire(key, ttl)
           end
         end
 

--- a/test/redis/store/ttl_test.rb
+++ b/test/redis/store/ttl_test.rb
@@ -38,7 +38,7 @@ class MockRedis
         @setnxes << a
       end
 
-      block.call
+      block.call(self)
     end
   end
   alias_method :pipelined, :multi


### PR DESCRIPTION
Context: https://github.com/redis/redis-rb/pull/1059

The following is deprecated
```ruby
redis.pipelined do
  redis.get(key)
end
```

And should be rewritten as:
```ruby
redis.pipelined do |pipeline|
  pipeline.get(key)
end
```

Functionally it makes no difference.