### PR TITLE
Remove deprecated global expectations

### DIFF
--- a/test/redis/distributed_store_test.rb
+++ b/test/redis/distributed_store_test.rb
@@ -19,7 +19,7 @@ describe "Redis::DistributedStore" do
     dmr = Redis::DistributedStore.new [ :host => "localhost", :port => "6380", :db => "1" ]
     dmr.ring.nodes.size == 1
     mr = dmr.ring.nodes.first
-    mr.to_s.must_equal("Redis Client connected to localhost:6380 against DB 1")
+    _(mr.to_s).must_equal("Redis Client connected to localhost:6380 against DB 1")
   end
 
   it "forces reconnection" do
@@ -32,11 +32,11 @@ describe "Redis::DistributedStore" do
 
   it "sets an object" do
     @dmr.set "rabbit", @white_rabbit
-    @dmr.get("rabbit").must_equal(@white_rabbit)
+    _(@dmr.get("rabbit")).must_equal(@white_rabbit)
   end
 
   it "gets an object" do
-    @dmr.get("rabbit").must_equal(@rabbit)
+    _(@dmr.get("rabbit")).must_equal(@rabbit)
   end
 
   it "mget" do
@@ -44,9 +44,9 @@ describe "Redis::DistributedStore" do
     begin
       @dmr.mget "rabbit", "rabbit2" do |rabbits|
         rabbit, rabbit2 = rabbits
-        rabbits.length.must_equal(2)
-        rabbit.must_equal(@rabbit)
-        rabbit2.must_equal(@white_rabbit)
+        _(rabbits.length).must_equal(2)
+        _(rabbit).must_equal(@rabbit)
+        _(rabbit2).must_equal(@white_rabbit)
       end
     rescue Redis::Distributed::CannotDistribute
       # Not supported on redis-rb < 4, and hence Ruby < 2.2.
@@ -57,9 +57,9 @@ describe "Redis::DistributedStore" do
     @dmr.set "rabbit2", @white_rabbit
     begin
       result = @dmr.mapped_mget("rabbit", "rabbit2")
-      result.keys.must_equal %w[ rabbit rabbit2 ]
-      result["rabbit"].must_equal @rabbit
-      result["rabbit2"].must_equal @white_rabbit
+      _(result.keys).must_equal %w[ rabbit rabbit2 ]
+      _(result["rabbit"]).must_equal @rabbit
+      _(result["rabbit2"]).must_equal @white_rabbit
     rescue Redis::Distributed::CannotDistribute
       # Not supported on redis-rb < 4, and hence Ruby < 2.2.
     end
@@ -70,7 +70,7 @@ describe "Redis::DistributedStore" do
                                     { :host => "localhost", :port => "6380", :db => 0 },
                                     { :host => "localhost", :port => "6381", :db => 0 }
                                 ], replicas: 1024
-    dmr.ring.replicas.must_equal 1024
+    _(dmr.ring.replicas).must_equal 1024
   end
 
   it "uses a custom ring object" do
@@ -79,8 +79,8 @@ describe "Redis::DistributedStore" do
                                           { :host => "localhost", :port => "6380", :db => 0 },
                                           { :host => "localhost", :port => "6381", :db => 0 }
                                       ], ring: my_ring
-    dmr.ring.must_equal my_ring
-    dmr.ring.nodes.length.must_equal 2
+    _(dmr.ring).must_equal my_ring
+    _(dmr.ring.nodes.length).must_equal 2
   end
 
   describe '#redis_version' do

--- a/test/redis/store/factory_test.rb
+++ b/test/redis/store/factory_test.rb
@@ -6,55 +6,55 @@ describe "Redis::Store::Factory" do
     describe "when not given any arguments" do
       it "instantiates Redis::Store" do
         store = Redis::Store::Factory.create
-        store.must_be_kind_of(Redis::Store)
-        store.to_s.must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0")
+        _(store).must_be_kind_of(Redis::Store)
+        _(store.to_s).must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0")
       end
     end
 
     describe "when given a Hash" do
       it "uses specified host" do
         store = Redis::Store::Factory.create :host => "localhost"
-        store.to_s.must_equal("Redis Client connected to localhost:6379 against DB 0")
+        _(store.to_s).must_equal("Redis Client connected to localhost:6379 against DB 0")
       end
 
       it "uses specified port" do
         store = Redis::Store::Factory.create :host => "localhost", :port => 6380
-        store.to_s.must_equal("Redis Client connected to localhost:6380 against DB 0")
+        _(store.to_s).must_equal("Redis Client connected to localhost:6380 against DB 0")
       end
 
       it "uses specified scheme" do
         store = Redis::Store::Factory.create :scheme => "rediss"
-        store.instance_variable_get(:@client).scheme.must_equal('rediss')
+        _(store.instance_variable_get(:@client).scheme).must_equal('rediss')
       end
 
       it "uses specified path" do
         store = Redis::Store::Factory.create :path => "/var/run/redis.sock"
-        store.to_s.must_equal("Redis Client connected to /var/run/redis.sock against DB 0")
+        _(store.to_s).must_equal("Redis Client connected to /var/run/redis.sock against DB 0")
       end
 
       it "uses specified db" do
         store = Redis::Store::Factory.create :host => "localhost", :port => 6380, :db => 13
-        store.to_s.must_equal("Redis Client connected to localhost:6380 against DB 13")
+        _(store.to_s).must_equal("Redis Client connected to localhost:6380 against DB 13")
       end
 
       it "uses specified namespace" do
         store = Redis::Store::Factory.create :namespace => "theplaylist"
-        store.to_s.must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist")
+        _(store.to_s).must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist")
       end
 
       it "uses specified key_prefix as namespace" do
         store = Redis::Store::Factory.create :key_prefix => "theplaylist"
-        store.to_s.must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist")
+        _(store.to_s).must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist")
       end
 
       it "uses specified password" do
         store = Redis::Store::Factory.create :password => "secret"
-        store.instance_variable_get(:@client).password.must_equal("secret")
+        _(store.instance_variable_get(:@client).password).must_equal("secret")
       end
 
       it 'uses empty password' do
         store = Redis::Store::Factory.create :password => ''
-        store.instance_variable_get(:@client).password.must_equal('')
+        _(store.instance_variable_get(:@client).password).must_equal('')
       end
 
       it 'uses nil password' do
@@ -64,30 +64,30 @@ describe "Redis::Store::Factory" do
 
       it "disables serialization" do
         store = Redis::Store::Factory.create :serializer => nil
-        store.instance_variable_get(:@serializer).must_be_nil
-        store.instance_variable_get(:@options)[:raw].must_equal(true)
+        _(store.instance_variable_get(:@serializer)).must_be_nil
+        _(store.instance_variable_get(:@options)[:raw]).must_equal(true)
       end
 
       it "configures pluggable serialization backend" do
         store = Redis::Store::Factory.create :serializer => JSON
-        store.instance_variable_get(:@serializer).must_equal(JSON)
-        store.instance_variable_get(:@options)[:raw].must_equal(false)
+        _(store.instance_variable_get(:@serializer)).must_equal(JSON)
+        _(store.instance_variable_get(:@options)[:raw]).must_equal(false)
       end
 
       describe "defaults" do
         it "defaults to localhost if no host specified" do
           store = Redis::Store::Factory.create
-          store.instance_variable_get(:@client).host.must_equal('127.0.0.1')
+          _(store.instance_variable_get(:@client).host).must_equal('127.0.0.1')
         end
 
         it "defaults to 6379 if no port specified" do
           store = Redis::Store::Factory.create
-          store.instance_variable_get(:@client).port.must_equal(6379)
+          _(store.instance_variable_get(:@client).port).must_equal(6379)
         end
 
         it "defaults to redis:// if no scheme specified" do
           store = Redis::Store::Factory.create
-          store.instance_variable_get(:@client).scheme.must_equal('redis')
+          _(store.instance_variable_get(:@client).scheme).must_equal('redis')
         end
       end
 
@@ -102,14 +102,14 @@ describe "Redis::Store::Factory" do
 
         it "disables marshalling and provides deprecation warning" do
           store = Redis::Store::Factory.create :marshalling => false
-          store.instance_variable_get(:@serializer).must_be_nil
-          store.instance_variable_get(:@options)[:raw].must_equal(true)
+          _(store.instance_variable_get(:@serializer)).must_be_nil
+          _(store.instance_variable_get(:@options)[:raw]).must_equal(true)
         end
 
         it "enables marshalling but provides warning to use :serializer instead" do
           store = Redis::Store::Factory.create :marshalling => true
-          store.instance_variable_get(:@serializer).must_equal(Marshal)
-          store.instance_variable_get(:@options)[:raw].must_equal(false)
+          _(store.instance_variable_get(:@serializer)).must_equal(Marshal)
+          _(store.instance_variable_get(:@options)[:raw]).must_equal(false)
         end
 
         after do
@@ -123,8 +123,8 @@ describe "Redis::Store::Factory" do
           { :host => "localhost", :port => 6379 },
           { :host => "localhost", :port => 6380 }
         )
-        store.must_be_kind_of(Redis::DistributedStore)
-        store.nodes.map { |node| node.to_s }.must_equal([
+        _(store).must_be_kind_of(Redis::DistributedStore)
+        _(store.nodes.map { |node| node.to_s }).must_equal([
           "Redis Client connected to localhost:6379 against DB 0",
           "Redis Client connected to localhost:6380 against DB 0",
         ])
@@ -134,62 +134,62 @@ describe "Redis::Store::Factory" do
     describe "when given a String" do
       it "uses specified host" do
         store = Redis::Store::Factory.create "redis://127.0.0.1"
-        store.to_s.must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0")
+        _(store.to_s).must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0")
       end
 
       it "uses specified port" do
         store = Redis::Store::Factory.create "redis://127.0.0.1:6380"
-        store.to_s.must_equal("Redis Client connected to 127.0.0.1:6380 against DB 0")
+        _(store.to_s).must_equal("Redis Client connected to 127.0.0.1:6380 against DB 0")
       end
 
       it "uses specified scheme" do
         store = Redis::Store::Factory.create "rediss://127.0.0.1:6380"
-        store.instance_variable_get(:@client).scheme.must_equal('rediss')
+        _(store.instance_variable_get(:@client).scheme).must_equal('rediss')
       end
 
       it "correctly defaults to redis:// when relative scheme specified" do
         store = Redis::Store::Factory.create "//127.0.0.1:6379"
-        store.instance_variable_get(:@client).scheme.must_equal('redis')
+        _(store.instance_variable_get(:@client).scheme).must_equal('redis')
       end
 
       it "uses specified path" do
         store = Redis::Store::Factory.create "unix:///var/run/redis.sock"
-        store.to_s.must_equal("Redis Client connected to /var/run/redis.sock against DB 0")
+        _(store.to_s).must_equal("Redis Client connected to /var/run/redis.sock against DB 0")
       end
 
       it "uses specified db" do
         store = Redis::Store::Factory.create "redis://127.0.0.1:6380/13"
-        store.to_s.must_equal("Redis Client connected to 127.0.0.1:6380 against DB 13")
+        _(store.to_s).must_equal("Redis Client connected to 127.0.0.1:6380 against DB 13")
       end
 
       it "uses specified namespace" do
         store = Redis::Store::Factory.create "redis://127.0.0.1:6379/0/theplaylist"
-        store.to_s.must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist")
+        _(store.to_s).must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist")
       end
 
       it "uses specified via query namespace" do
         store = Redis::Store::Factory.create "redis://127.0.0.1:6379/0?namespace=theplaylist"
-        store.to_s.must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist")
+        _(store.to_s).must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist")
       end
 
       it "uses specified namespace with path" do
         store = Redis::Store::Factory.create "unix:///var/run/redis.sock?db=2&namespace=theplaylist"
-        store.to_s.must_equal("Redis Client connected to /var/run/redis.sock against DB 2 with namespace theplaylist")
+        _(store.to_s).must_equal("Redis Client connected to /var/run/redis.sock against DB 2 with namespace theplaylist")
       end
 
       it "uses specified password" do
         store = Redis::Store::Factory.create "redis://:secret@127.0.0.1:6379/0/theplaylist"
-        store.instance_variable_get(:@client).password.must_equal("secret")
+        _(store.instance_variable_get(:@client).password).must_equal("secret")
       end
 
       it 'uses specified password with special characters' do
         store = Redis::Store::Factory.create 'redis://:pwd%40123@127.0.0.1:6379/0/theplaylist'
-        store.instance_variable_get(:@client).password.must_equal('pwd@123')
+        _(store.instance_variable_get(:@client).password).must_equal('pwd@123')
       end
 
       it 'uses empty password' do
         store = Redis::Store::Factory.create 'redis://:@127.0.0.1:6379/0/theplaylist'
-        store.instance_variable_get(:@client).password.must_equal('')
+        _(store.instance_variable_get(:@client).password).must_equal('')
       end
 
       it 'uses nil password' do
@@ -199,14 +199,14 @@ describe "Redis::Store::Factory" do
 
       it "correctly uses specified ipv6 host" do
         store = Redis::Store::Factory.create "redis://[::1]:6380"
-        store.to_s.must_equal("Redis Client connected to [::1]:6380 against DB 0")
-        store.instance_variable_get('@options')[:host].must_equal("::1")
+        _(store.to_s).must_equal("Redis Client connected to [::1]:6380 against DB 0")
+        _(store.instance_variable_get('@options')[:host]).must_equal("::1")
       end
 
       it "instantiates Redis::DistributedStore" do
         store = Redis::Store::Factory.create "redis://127.0.0.1:6379", "redis://127.0.0.1:6380"
-        store.must_be_kind_of(Redis::DistributedStore)
-        store.nodes.map { |node| node.to_s }.must_equal([
+        _(store).must_be_kind_of(Redis::DistributedStore)
+        _(store.nodes.map { |node| node.to_s }).must_equal([
           "Redis Client connected to 127.0.0.1:6379 against DB 0",
           "Redis Client connected to 127.0.0.1:6380 against DB 0",
         ])
@@ -227,7 +227,7 @@ describe "Redis::Store::Factory" do
           { :host => '127.0.0.1', :port => '6380' },
           { :namespace => 'theplaylist' }
         )
-        store.nodes.map { |node| node.to_s }.must_equal([
+        _(store.nodes.map { |node| node.to_s }).must_equal([
           "Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist",
           "Redis Client connected to 127.0.0.1:6380 against DB 0 with namespace theplaylist"
         ])
@@ -237,12 +237,12 @@ describe "Redis::Store::Factory" do
     describe 'when given host String and options Hash' do
       it 'instantiates Redis::Store and merges options' do
         store = Redis::Store::Factory.create "redis://127.0.0.1", :namespace => 'theplaylist'
-        store.to_s.must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist")
+        _(store.to_s).must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist")
       end
 
       it 'instantiates Redis::DistributedStore and merges options' do
         store = Redis::Store::Factory.create "redis://127.0.0.1:6379", "redis://127.0.0.1:6380", :namespace => 'theplaylist'
-        store.nodes.map { |node| node.to_s }.must_equal([
+        _(store.nodes.map { |node| node.to_s }).must_equal([
           "Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist",
           "Redis Client connected to 127.0.0.1:6380 against DB 0 with namespace theplaylist",
         ])
@@ -250,7 +250,7 @@ describe "Redis::Store::Factory" do
 
       it 'instantiates Redis::Store and sets namespace from String' do
         store = Redis::Store::Factory.create "redis://127.0.0.1:6379/0/theplaylist", :expire_after => 5
-        store.to_s.must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist")
+        _(store.to_s).must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0 with namespace theplaylist")
       end
     end
   end

--- a/test/redis/store/namespace_test.rb
+++ b/test/redis/store/namespace_test.rb
@@ -30,7 +30,7 @@ describe "Redis::Store::Namespace" do
   end
 
   it "doesn't namespace a key which is already namespaced" do
-    @store.send(:interpolate, "#{@namespace}:rabbit").must_equal("#{@namespace}:rabbit")
+    _(@store.send(:interpolate, "#{@namespace}:rabbit")).must_equal("#{@namespace}:rabbit")
   end
 
   it "should only delete namespaced keys" do
@@ -38,26 +38,26 @@ describe "Redis::Store::Namespace" do
     @store.set 'def', 'fed'
 
     @store.flushdb
-    @store.get('def').must_be_nil
-    @default_store.get('abc').must_equal('cba')
+    _(@store.get('def')).must_be_nil
+    _(@default_store.get('abc')).must_equal('cba')
   end
 
   it 'should allow to change namespace on the fly' do
     @default_store.set 'abc', 'cba'
     @other_store.set 'foo', 'bar'
 
-    @default_store.keys.sort.must_equal ['abc', 'other:foo']
+    _(@default_store.keys.sort).must_equal ['abc', 'other:foo']
 
     @default_store.with_namespace(@other_namespace) do
-      @default_store.keys.must_equal ['foo']
-      @default_store.get('foo').must_equal('bar')
+      _(@default_store.keys).must_equal ['foo']
+      _(@default_store.get('foo')).must_equal('bar')
     end
   end
 
   it "should not try to delete missing namespaced keys" do
     empty_store = Redis::Store.new :namespace => 'empty'
     empty_store.flushdb
-    empty_store.keys.must_be_empty
+    _(empty_store.keys).must_be_empty
   end
 
   it "should work with dynamic namespace" do
@@ -74,7 +74,7 @@ describe "Redis::Store::Namespace" do
     r2 = dyn_store.get 'key'
     $ns = "ns1"
     r1 = dyn_store.get 'key'
-    r1.must_equal('x') && r2.must_equal('y') && r3.must_be_nil
+    _(r1).must_equal('x') && _(r2).must_equal('y') && _(r3).must_be_nil
   end
 
   it "namespaces setex and ttl" do
@@ -82,11 +82,11 @@ describe "Redis::Store::Namespace" do
     @other_store.flushdb
 
     @store.setex('foo', 30, 'bar')
-    @store.ttl('foo').must_be_close_to(30)
-    @store.get('foo').must_equal('bar')
+    _(@store.ttl('foo')).must_be_close_to(30)
+    _(@store.get('foo')).must_equal('bar')
 
-    @other_store.ttl('foo').must_equal(-2)
-    @other_store.get('foo').must_be_nil
+    _(@other_store.ttl('foo')).must_equal(-2)
+    _(@other_store.get('foo')).must_be_nil
   end
 
   describe 'method calls' do
@@ -120,7 +120,7 @@ describe "Redis::Store::Namespace" do
 
     it "should namespace keys" do
       store.set "rabbit", @rabbit
-      store.keys("rabb*").must_equal [ "rabbit" ]
+      _(store.keys("rabb*")).must_equal [ "rabbit" ]
     end
 
     it "should namespace scan when a pattern is given" do
@@ -131,7 +131,7 @@ describe "Redis::Store::Namespace" do
         cursor, matched_keys = store.scan(cursor, match: "rabb*")
         keys = keys.concat(matched_keys) unless matched_keys.empty?
       end until cursor == "0"
-      keys.must_equal [ "rabbit" ]
+      _(keys).must_equal [ "rabbit" ]
     end
 
     it "should namespace exists" do
@@ -152,16 +152,16 @@ describe "Redis::Store::Namespace" do
     it "should namespace mget" do
       client.expects(:call).with([:mget, "#{@namespace}:rabbit", "#{@namespace}:white_rabbit"]).returns(%w[ foo bar ])
       store.mget "rabbit", "white_rabbit" do |result|
-        result.must_equal(%w[ foo bar ])
+        _(result).must_equal(%w[ foo bar ])
       end
     end
 
     it "should namespace mapped_mget" do
       client.expects(:process).with([[:mget, "#{@namespace}:rabbit", "#{@namespace}:white_rabbit"]]).returns(%w[ foo bar ])
       result = store.mapped_mget "rabbit", "white_rabbit"
-      result.keys.must_equal %w[ rabbit white_rabbit ]
-      result["rabbit"].must_equal "foo"
-      result["white_rabbit"].must_equal "bar"
+      _(result.keys).must_equal %w[ rabbit white_rabbit ]
+      _(result["rabbit"]).must_equal "foo"
+      _(result["white_rabbit"]).must_equal "bar"
     end
 
     it "should namespace expire" do
@@ -271,14 +271,14 @@ describe "Redis::Store::Namespace" do
       store.hscan_each("rabbit") do |key|
         results << key
       end
-      results.must_equal(["key1"])
+      _(results).must_equal(["key1"])
     end
 
     it "should namespace hscan_each without block" do
       client.call([:hset, "#{@namespace}:rabbit", "key1", @rabbit])
       client.expects(:call).with([:hscan, "#{@namespace}:rabbit", 0]).returns(["0", ["key1"]])
       results = store.hscan_each("rabbit").to_a
-      results.must_equal(["key1"])
+      _(results).must_equal(["key1"])
     end
 
     it "should namespace zincrby" do

--- a/test/redis/store/redis_version_test.rb
+++ b/test/redis/store/redis_version_test.rb
@@ -11,18 +11,18 @@ describe "Redis::RedisVersion" do
 
   describe '#redis_version' do
     it 'returns redis version' do
-      @store.redis_version.to_s.must_match(/^\d{1}\.\d{1,}\.\d{1,}$/)
+      _(@store.redis_version.to_s).must_match(/^\d{1}\.\d{1,}\.\d{1,}$/)
     end
   end
 
   describe '#supports_redis_version?' do
     it 'returns true if redis version is greater or equal to required version' do
       @store.stubs(:redis_version).returns('2.8.19')
-      @store.supports_redis_version?('2.6.0').must_equal(true)
-      @store.supports_redis_version?('2.8.19').must_equal(true)
-      @store.supports_redis_version?('2.8.20').must_equal(false)
-      @store.supports_redis_version?('2.9.0').must_equal(false)
-      @store.supports_redis_version?('3.0.0').must_equal(false)
+      _(@store.supports_redis_version?('2.6.0')).must_equal(true)
+      _(@store.supports_redis_version?('2.8.19')).must_equal(true)
+      _(@store.supports_redis_version?('2.8.20')).must_equal(false)
+      _(@store.supports_redis_version?('2.9.0')).must_equal(false)
+      _(@store.supports_redis_version?('3.0.0')).must_equal(false)
     end
   end
 end

--- a/test/redis/store/serialization_test.rb
+++ b/test/redis/store/serialization_test.rb
@@ -15,68 +15,68 @@ describe "Redis::Serialization" do
   end
 
   it "unmarshals on get" do
-    @store.get("rabbit").must_equal(@rabbit)
+    _(@store.get("rabbit")).must_equal(@rabbit)
   end
 
   it "marshals on set" do
     @store.set "rabbit", @white_rabbit
-    @store.get("rabbit").must_equal(@white_rabbit)
+    _(@store.get("rabbit")).must_equal(@white_rabbit)
   end
 
   it "marshals on multi set" do
     @store.mset("rabbit", @white_rabbit, "rabbit2", @rabbit)
-    @store.get("rabbit").must_equal(@white_rabbit)
-    @store.get("rabbit2").must_equal(@rabbit)
+    _(@store.get("rabbit")).must_equal(@white_rabbit)
+    _(@store.get("rabbit2")).must_equal(@rabbit)
   end
 
   if RUBY_VERSION.match /1\.9/
     it "doesn't unmarshal on get if raw option is true" do
-      @store.get("rabbit", :raw => true).must_equal("\x04\bU:\x0FOpenStruct{\x06:\tnameI\"\nbunny\x06:\x06EF")
+      _(@store.get("rabbit", :raw => true)).must_equal("\x04\bU:\x0FOpenStruct{\x06:\tnameI\"\nbunny\x06:\x06EF")
     end
   else
     it "doesn't unmarshal on get if raw option is true" do
-      @store.get("rabbit", :raw => true).must_include("\x04\bU:\x0FOpenStruct{\x06:\tname")
+      _(@store.get("rabbit", :raw => true)).must_include("\x04\bU:\x0FOpenStruct{\x06:\tname")
     end
   end
 
   it "doesn't marshal set if raw option is true" do
     @store.set "rabbit", @white_rabbit, :raw => true
-    @store.get("rabbit", :raw => true).must_equal(%(#<OpenStruct color="white">))
+    _(@store.get("rabbit", :raw => true)).must_equal(%(#<OpenStruct color="white">))
   end
 
   it "doesn't marshal multi set if raw option is true" do
     @store.mset("rabbit", @white_rabbit, "rabbit2", @rabbit, :raw => true)
-    @store.get("rabbit", :raw => true).must_equal(%(#<OpenStruct color="white">))
-    @store.get("rabbit2", :raw => true).must_equal(%(#<OpenStruct name="bunny">))
+    _(@store.get("rabbit", :raw => true)).must_equal(%(#<OpenStruct color="white">))
+    _(@store.get("rabbit2", :raw => true)).must_equal(%(#<OpenStruct name="bunny">))
   end
 
   it "doesn't unmarshal if get returns an empty string" do
     @store.set "empty_string", ""
-    @store.get("empty_string").must_equal("")
+    _(@store.get("empty_string")).must_equal("")
     # TODO use a meaningful Exception
     # lambda { @store.get("empty_string").must_equal("") }.wont_raise Exception
   end
 
   it "doesn't set an object if already exist" do
     @store.setnx "rabbit", @white_rabbit
-    @store.get("rabbit").must_equal(@rabbit)
+    _(@store.get("rabbit")).must_equal(@rabbit)
   end
 
   it "marshals on set unless exists" do
     @store.setnx "rabbit2", @white_rabbit
-    @store.get("rabbit2").must_equal(@white_rabbit)
+    _(@store.get("rabbit2")).must_equal(@white_rabbit)
   end
 
   it "doesn't marshal on set unless exists if raw option is true" do
     @store.setnx "rabbit2", @white_rabbit, :raw => true
-    @store.get("rabbit2", :raw => true).must_equal(%(#<OpenStruct color="white">))
+    _(@store.get("rabbit2", :raw => true)).must_equal(%(#<OpenStruct color="white">))
   end
 
   it "marshals on set expire" do
     @store.setex "rabbit2", 1, @white_rabbit
-    @store.get("rabbit2").must_equal(@white_rabbit)
+    _(@store.get("rabbit2")).must_equal(@white_rabbit)
     sleep 2
-    @store.get("rabbit2").must_be_nil
+    _(@store.get("rabbit2")).must_be_nil
   end
 
   it "marshals setex (over a distributed store)" do
@@ -85,7 +85,7 @@ describe "Redis::Serialization" do
       { :host => "localhost", :port => "6381", :db => 0 }
     ]
     @store.setex "rabbit", 50, @white_rabbit
-    @store.get("rabbit").must_equal(@white_rabbit)
+    _(@store.get("rabbit")).must_equal(@white_rabbit)
   end
 
   it "doesn't marshal setex if raw option is true (over a distributed store)" do
@@ -94,41 +94,41 @@ describe "Redis::Serialization" do
       { :host => "localhost", :port => "6381", :db => 0 }
     ]
     @store.setex "rabbit", 50, @white_rabbit, :raw => true
-    @store.get("rabbit", :raw => true).must_equal(%(#<OpenStruct color="white">))
+    _(@store.get("rabbit", :raw => true)).must_equal(%(#<OpenStruct color="white">))
   end
 
   it "unmarshals on multi get" do
     @store.set "rabbit2", @white_rabbit
     @store.mget "rabbit", "rabbit2" do |rabbits|
       rabbit, rabbit2 = rabbits
-      rabbits.length.must_equal(2)
-      rabbit.must_equal(@rabbit)
-      rabbit2.must_equal(@white_rabbit)
+      _(rabbits.length).must_equal(2)
+      _(rabbit).must_equal(@rabbit)
+      _(rabbit2).must_equal(@white_rabbit)
     end
   end
 
   it "unmarshals on mapped_mget" do
     @store.set "rabbit2", @white_rabbit
     result = @store.mapped_mget("rabbit", "rabbit2")
-    result.keys.must_equal %w[ rabbit rabbit2 ]
-    result["rabbit"].must_equal @rabbit
-    result["rabbit2"].must_equal @white_rabbit
+    _(result.keys).must_equal %w[ rabbit rabbit2 ]
+    _(result["rabbit"]).must_equal @rabbit
+    _(result["rabbit2"]).must_equal @white_rabbit
   end
 
   if RUBY_VERSION.match /1\.9/
     it "doesn't unmarshal on multi get if raw option is true" do
       @store.set "rabbit2", @white_rabbit
       @store.mget "rabbit", "rabbit2", :raw => true do |rabbit, rabbit2|
-        rabbit.must_equal("\x04\bU:\x0FOpenStruct{\x06:\tnameI\"\nbunny\x06:\x06EF")
-        rabbit2.must_equal("\x04\bU:\x0FOpenStruct{\x06:\ncolorI\"\nwhite\x06:\x06EF")
+        _(rabbit).must_equal("\x04\bU:\x0FOpenStruct{\x06:\tnameI\"\nbunny\x06:\x06EF")
+        _(rabbit2).must_equal("\x04\bU:\x0FOpenStruct{\x06:\ncolorI\"\nwhite\x06:\x06EF")
       end
     end
   else
     it "doesn't unmarshal on multi get if raw option is true" do
       @store.set "rabbit2", @white_rabbit
       @store.mget "rabbit", "rabbit2", :raw => true do |rabbit, rabbit2|
-        rabbit.must_include("\x04\bU:\x0FOpenStruct{\x06:\tname")
-        rabbit2.must_include("\x04\bU:\x0FOpenStruct{\x06:\ncolor")
+        _(rabbit).must_include("\x04\bU:\x0FOpenStruct{\x06:\tname")
+        _(rabbit2).must_include("\x04\bU:\x0FOpenStruct{\x06:\ncolor")
       end
     end
   end
@@ -139,7 +139,7 @@ describe "Redis::Serialization" do
       ascii_rabbit = OpenStruct.new(:name => [128].pack("C*"))
 
       @store.set(utf8_key, ascii_rabbit)
-      @store.get(utf8_key).must_equal(ascii_rabbit)
+      _(@store.get(utf8_key)).must_equal(ascii_rabbit)
     end
 
     it "gets and sets raw values" do
@@ -147,7 +147,7 @@ describe "Redis::Serialization" do
       ascii_string = [128].pack("C*")
 
       @store.set(utf8_key, ascii_string, :raw => true)
-      @store.get(utf8_key, :raw => true).bytes.to_a.must_equal(ascii_string.bytes.to_a)
+      _(@store.get(utf8_key, :raw => true).bytes.to_a).must_equal(ascii_string.bytes.to_a)
     end
 
     it "marshals objects on setnx" do
@@ -156,7 +156,7 @@ describe "Redis::Serialization" do
 
       @store.del(utf8_key)
       @store.setnx(utf8_key, ascii_rabbit)
-      @store.get(utf8_key).must_equal(ascii_rabbit)
+      _(@store.get(utf8_key)).must_equal(ascii_rabbit)
     end
 
     it "gets and sets raw values on setnx" do
@@ -165,7 +165,7 @@ describe "Redis::Serialization" do
 
       @store.del(utf8_key)
       @store.setnx(utf8_key, ascii_string, :raw => true)
-      @store.get(utf8_key, :raw => true).bytes.to_a.must_equal(ascii_string.bytes.to_a)
+      _(@store.get(utf8_key, :raw => true).bytes.to_a).must_equal(ascii_string.bytes.to_a)
     end
   end if defined?(Encoding)
 end

--- a/test/redis/store/ttl_test.rb
+++ b/test/redis/store/ttl_test.rb
@@ -66,14 +66,14 @@ describe MockTtlStore do
     describe 'without options' do
       it 'must call super with key and value' do
         redis.set(key, mock_value)
-        redis.has_set?(key, mock_value, nil).must_equal true
+        _(redis.has_set?(key, mock_value, nil)).must_equal true
       end
     end
 
     describe 'with options' do
       it 'must call setex with proper expiry and set raw to true' do
         redis.set(key, mock_value, options)
-        redis.has_setex?(key, options[:expire_after], mock_value, :raw => true).must_equal true
+        _(redis.has_setex?(key, options[:expire_after], mock_value, :raw => true)).must_equal true
       end
     end
 
@@ -81,7 +81,7 @@ describe MockTtlStore do
       it 'must call super with key and value and options' do
         set_options = { nx: true, ex: 3600 }
         redis.set(key, mock_value, set_options)
-        redis.has_set?(key, mock_value, set_options).must_equal true
+        _(redis.has_set?(key, mock_value, set_options)).must_equal true
       end
     end
   end
@@ -107,12 +107,12 @@ describe MockTtlStore do
 
       it 'must call setnx with key and value and set raw to true' do
         redis.setnx(key, mock_value, options)
-        redis.has_setnx?(key, mock_value, :raw => true).must_equal true
+        _(redis.has_setnx?(key, mock_value, :raw => true)).must_equal true
       end
 
       it 'must call expire' do
         redis.setnx(key, mock_value, options)
-        redis.has_expire?(key, options[:expire_after]).must_equal true
+        _(redis.has_expire?(key, options[:expire_after])).must_equal true
       end
 
       describe 'avoiding multi commands' do
@@ -125,12 +125,12 @@ describe MockTtlStore do
 
         it 'must call setnx with key and value and set raw to true' do
           redis.setnx(key, mock_value, options)
-          redis.has_setnx?(key, mock_value, :raw => true).must_equal true
+          _(redis.has_setnx?(key, mock_value, :raw => true)).must_equal true
         end
 
         it 'must call expire' do
           redis.setnx(key, mock_value, options)
-          redis.has_expire?(key, options[:expire_after]).must_equal true
+          _(redis.has_expire?(key, options[:expire_after])).must_equal true
         end
       end
 
@@ -144,12 +144,12 @@ describe MockTtlStore do
 
         it 'must call setnx with key and value and set raw to true' do
           redis.setnx(key, mock_value, options)
-          redis.has_setnx?(key, mock_value, :raw => true).must_equal true
+          _(redis.has_setnx?(key, mock_value, :raw => true)).must_equal true
         end
 
         it 'must call expire' do
           redis.setnx(key, mock_value, options)
-          redis.has_expire?(key, options[:expire_after]).must_equal true
+          _(redis.has_expire?(key, options[:expire_after])).must_equal true
         end
       end
     end

--- a/test/redis/store/version_test.rb
+++ b/test/redis/store/version_test.rb
@@ -2,6 +2,6 @@ require 'test_helper'
 
 describe Redis::Store::VERSION do
   it 'returns current version' do
-    Redis::Store::VERSION.wont_equal nil
+    _(Redis::Store::VERSION).wont_equal nil
   end
 end

--- a/test/redis/store_test.rb
+++ b/test/redis/store_test.rb
@@ -12,7 +12,7 @@ describe Redis::Store do
   end
 
   it "returns useful informations about the server" do
-    @store.to_s.must_equal("Redis Client connected to #{@client.host}:#{@client.port} against DB #{@client.db}")
+    _(@store.to_s).must_equal("Redis Client connected to #{@client.host}:#{@client.port} against DB #{@client.db}")
   end
 
   it "must force reconnection" do
@@ -41,15 +41,15 @@ describe Redis::Store do
 
         # without options no ex or nx will be set
         @store.del(key)
-        @store.set(key, mock_value, {}).must_equal 'OK'
-        @store.set(key, mock_value, {}).must_equal 'OK'
-        @store.ttl(key).must_equal -1
+        _(@store.set(key, mock_value, {})).must_equal 'OK'
+        _(@store.set(key, mock_value, {})).must_equal 'OK'
+        _(@store.ttl(key)).must_equal -1
 
         # with ex and nx options, the key can only be set once and a ttl will be set
         @store.del(key)
-        @store.set(key, mock_value, options).must_equal true
-        @store.set(key, mock_value, options).must_equal false
-        @store.ttl(key).must_equal 3600
+        _(@store.set(key, mock_value, options)).must_equal true
+        _(@store.set(key, mock_value, options)).must_equal false
+        _(@store.ttl(key)).must_equal 3600
       end
     end
   end


### PR DESCRIPTION
Current master code shows too many minitest warning messages.

I think these messages are too noisy.

```
$ bundle exec rake redis:test:run                                                                                                                                  
...

# Running:                                                                                                                                                         
                                                                                                                                                                   
.DEPRECATED: global use of must_equal from /Users/hogelog/repos/oss/redis-store/test/redis/store/factory_test.rb:253. Use _(obj).must_equal instead. This will fail
 in Minitest 6.                                                                                                                                                    
.DEPRECATED: global use of must_equal from /Users/hogelog/repos/oss/redis-store/test/redis/store/factory_test.rb:245. Use _(obj).must_equal instead. This will fail in Minitest 6.                                                                                                                                                    .DEPRECATED: global use of must_equal from /Users/hogelog/repos/oss/redis-store/test/redis/store/factory_test.rb:240. Use _(obj).must_equal instead. This will fail
 in Minitest 6.                                                                                                                                                    
.DEPRECATED: global use of must_match from /Users/hogelog/repos/oss/redis-store/test/redis/store/redis_version_test.rb:14. Use _(obj).must_match instead. This will
 fail in Minitest 6.                                                                                                                                               
...
```

This PR changes are created by below script.

```sh
gem install rubocop-minitest

cat > _tmp-rubocop.yml <<YML
require: rubocop-minitest

AllCops:
  DisabledByDefault: true
Minitest/GlobalExpectations:
  Enabled: true
YML
rubocop -c _tmp-rubocop.yml -a test/
```