### PR TITLE
Stop passing empty hash or nil to super in `Redis::Store::Ttl#set`

### DIFF
--- a/lib/redis/store/ttl.rb
+++ b/lib/redis/store/ttl.rb
@@ -4,8 +4,10 @@ class Redis
       def set(key, value, options = nil)
         if ttl = expires_in(options)
           setex(key, ttl.to_i, value, :raw => true)
+        elsif options
+          super(key, value, **options)
         else
-          super(key, value, options)
+          super(key, value)
         end
       end
 

--- a/test/redis/store/ttl_test.rb
+++ b/test/redis/store/ttl_test.rb
@@ -66,7 +66,7 @@ describe MockTtlStore do
     describe 'without options' do
       it 'must call super with key and value' do
         redis.set(key, mock_value)
-        _(redis.has_set?(key, mock_value, nil)).must_equal true
+        _(redis.has_set?(key, mock_value)).must_equal true
       end
     end
 


### PR DESCRIPTION
 ### Summary
 Currently when upgrading to Ruby 3 some issues are produced in `redis-store`, specifically in the method `set` in `Redis::Store::Ttl`. 
 
Since [`redis` version `4.2`](https://github.com/redis/redis-rb/commit/1e5d0a15f7f1e7d290b90bbd4191e5622e95b6a1#diff-be7250cec80fe7f394651422fa93e5305524231d080952fd3bd5cb005102f332R816) the method `set` changed and now uses keyword arguments instead of an option hash. The current code allows to pass an empty hash or nil to super which wouldn't be correct. 

This PR changes this using the `**` operator when a hash is present and not sending options if it's nil.

The CI failing is not related to the changes in the PR as master currently failing those checks.