### PR TITLE
Bump to v1.10.0

### DIFF
--- a/lib/redis/store/version.rb
+++ b/lib/redis/store/version.rb
@@ -1,6 +1,6 @@
 class Redis
   class Store < self
-    VERSION = '1.9.2'
+    VERSION = '1.10.0'
 
     def self.redis_client_defined?
       # Doesn't work if declared as constant


### PR DESCRIPTION
Off the back of https://github.com/redis-store/redis-store/discussions/366, we will need to bump the version number before we can do another release.