### PR TITLE
Set client option `:ssl` to true when URI scheme is `rediss://`

### DIFF
--- a/lib/redis/store/factory.rb
+++ b/lib/redis/store/factory.rb
@@ -78,7 +78,8 @@ class Redis
             :scheme   => uri.scheme,
             :host     => uri.hostname,
             :port     => uri.port || DEFAULT_PORT,
-            :password => uri.password.nil? ? nil : CGI.unescape(uri.password.to_s)
+            :password => uri.password.nil? ? nil : CGI.unescape(uri.password.to_s),
+            :ssl      => uri.scheme == 'rediss'
           }
 
           options[:db]        = db.to_i   if db

--- a/test/redis/store/factory_test.rb
+++ b/test/redis/store/factory_test.rb
@@ -148,7 +148,12 @@ describe "Redis::Store::Factory" do
         store = Redis::Store::Factory.create "redis://127.0.0.1"
         _(store.to_s).must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0")
         client = store.instance_variable_get(:@client)
-        assert_equal(false, client.options[:ssl])
+
+        if Gem::Version.new(Redis::VERSION) >= Gem::Version.new('5.0.0')
+          assert_equal(false, client.instance_variable_get(:@config).instance_variable_get(:@ssl))
+        else
+          assert_equal(false, client.options[:ssl])
+        end
       end
 
       it "uses specified port" do
@@ -161,7 +166,13 @@ describe "Redis::Store::Factory" do
         client = store.instance_variable_get(:@client)
         # `redis-client` does NOT have `scheme`
         client.respond_to?(:scheme) && _(client.scheme).must_equal('rediss')
-        assert_equal(true, client.options[:ssl])
+
+        if Gem::Version.new(Redis::VERSION) >= Gem::Version.new('5.0.0')
+          # binding.irb
+          assert_equal(true, client.instance_variable_get(:@config).instance_variable_get(:@ssl))
+        else
+          assert_equal(true, client.options[:ssl])
+        end
       end
 
       it "correctly defaults to redis:// when relative scheme specified" do

--- a/test/redis/store/factory_test.rb
+++ b/test/redis/store/factory_test.rb
@@ -147,6 +147,8 @@ describe "Redis::Store::Factory" do
       it "uses specified host" do
         store = Redis::Store::Factory.create "redis://127.0.0.1"
         _(store.to_s).must_equal("Redis Client connected to 127.0.0.1:6379 against DB 0")
+        client = store.instance_variable_get(:@client)
+        assert_equal(false, client.options[:ssl])
       end
 
       it "uses specified port" do
@@ -159,6 +161,7 @@ describe "Redis::Store::Factory" do
         client = store.instance_variable_get(:@client)
         # `redis-client` does NOT have `scheme`
         client.respond_to?(:scheme) && _(client.scheme).must_equal('rediss')
+        assert_equal(true, client.options[:ssl])
       end
 
       it "correctly defaults to redis:// when relative scheme specified" do


### PR DESCRIPTION
## What

When `Redis::Store` is initialized with a URI that has a scheme of `rediss://`, the client option `:ssl` should be set to `true`. However, the scheme option is deleted because the redis-client does not have a `scheme` in the `_remove_unsupported_options` method.

Then `Redis::Client` only knows host, port, and password, and didn't connect with SSL.
So if the passed URL has `rediss://` scheme, to tell `Redis::Client` needs to connect with ssl make `:ssl` option to `ture`