### PR TITLE
Support Redis usernames

### DIFF
--- a/lib/redis/store.rb
+++ b/lib/redis/store.rb
@@ -71,6 +71,8 @@ class Redis
         options.delete(:marshalling)
         options.delete(:namespace)
         options.delete(:scheme)
+        # Redis ACL support added in https://github.com/redis/redis-rb/pull/967
+        options.delete(:username) unless Gem::Version.new(Redis::VERSION) >= Gem::Version.new("4.3.0")
       end
 
       def _extend_marshalling

--- a/lib/redis/store/factory.rb
+++ b/lib/redis/store/factory.rb
@@ -78,14 +78,16 @@ class Redis
             :scheme   => uri.scheme,
             :host     => uri.hostname,
             :port     => uri.port || DEFAULT_PORT,
-            :password => uri.password.nil? ? nil : CGI.unescape(uri.password.to_s),
             :ssl      => uri.scheme == 'rediss'
           }
 
           options[:db]        = db.to_i   if db
           options[:namespace] = namespace if namespace
-          options[:username]  = uri.user if uri.user
         end
+
+        options[:username] = uri.user if uri.user
+        options[:password] = CGI.unescape(uri.password.to_s) if uri.password
+
         if uri.query
           query = Hash[URI.decode_www_form(uri.query)]
           query.each do |(key, value)|

--- a/lib/redis/store/factory.rb
+++ b/lib/redis/store/factory.rb
@@ -84,6 +84,7 @@ class Redis
 
           options[:db]        = db.to_i   if db
           options[:namespace] = namespace if namespace
+          options[:username]  = uri.user if uri.user
         end
         if uri.query
           query = Hash[URI.decode_www_form(uri.query)]

--- a/test/redis/store/factory_test.rb
+++ b/test/redis/store/factory_test.rb
@@ -213,6 +213,12 @@ describe "Redis::Store::Factory" do
       end
 
       if Gem::Version.new(Redis::VERSION) >= Gem::Version.new("4.3.0")
+        it "uses specified path with username and password" do
+          store = Redis::Store::Factory.create "unix://test-user:secret@/var/run/redis.sock"
+          _(store.instance_variable_get(:@client).username).must_equal("test-user")
+          _(store.instance_variable_get(:@client).password).must_equal("secret")
+        end
+
         it "uses specified username and password" do
           store = Redis::Store::Factory.create "redis://test-user:secret@127.0.0.1:6379/0/theplaylist"
           _(store.instance_variable_get(:@client).username).must_equal("test-user")

--- a/test/redis/store/factory_test.rb
+++ b/test/redis/store/factory_test.rb
@@ -212,6 +212,14 @@ describe "Redis::Store::Factory" do
         _(store.instance_variable_get(:@client).password).must_equal("secret")
       end
 
+      if Gem::Version.new(Redis::VERSION) >= Gem::Version.new("4.3.0")
+        it "uses specified username and password" do
+          store = Redis::Store::Factory.create "redis://test-user:secret@127.0.0.1:6379/0/theplaylist"
+          _(store.instance_variable_get(:@client).username).must_equal("test-user")
+          _(store.instance_variable_get(:@client).password).must_equal("secret")
+        end
+      end
+
       it 'uses specified password with special characters' do
         store = Redis::Store::Factory.create 'redis://:pwd%40123@127.0.0.1:6379/0/theplaylist'
         _(store.instance_variable_get(:@client).password).must_equal('pwd@123')


### PR DESCRIPTION
https://github.com/redis/redis-rb/pull/967 added support for Redis ACL usernames in the redis gem v4.3.0. Pass the `username` option if the Redis client supports this.

This pull request also adds Redis ACL support for UNIX sockets.