### PR TITLE
Fix handling of default username

### DIFF
--- a/lib/redis/store/factory.rb
+++ b/lib/redis/store/factory.rb
@@ -85,7 +85,10 @@ class Redis
           options[:namespace] = namespace if namespace
         end
 
-        options[:username] = uri.user if uri.user
+        if uri.user && !uri.user.empty?
+          options[:username] = uri.user
+        end
+
         options[:password] = CGI.unescape(uri.password.to_s) if uri.password
 
         if uri.query

--- a/test/redis/store/factory_test.rb
+++ b/test/redis/store/factory_test.rb
@@ -224,6 +224,14 @@ describe "Redis::Store::Factory" do
           _(store.instance_variable_get(:@client).username).must_equal("test-user")
           _(store.instance_variable_get(:@client).password).must_equal("secret")
         end
+
+        it "uses a default username" do
+          store = Redis::Store::Factory.create "redis://:secret@127.0.0.1:6379/0/theplaylist"
+          username = Gem::Version.new(Redis::VERSION) >= Gem::Version.new("5.0") ? "default" : nil
+
+          _(store.instance_variable_get(:@client).username).must_equal(username)
+          _(store.instance_variable_get(:@client).password).must_equal("secret")
+        end
       end
 
       it 'uses specified password with special characters' do


### PR DESCRIPTION
There was a regression caused by https://github.com/redis-store/redis-store/pull/373 when only a password was specified. `URI#user` returned a blank value instead of `nil`.